### PR TITLE
Permit whitelisting of expected properties.  Test coverage.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -175,6 +175,14 @@ assertj.swagger.definitionsToIgnoreInExpected=\
    Bar
 ----
 
+To ignore unimplemented properties, use something like:
+
+[source]
+----
+assertj.swagger.propertiesToIgnoreInExpected=\
+   Foo.prop1,\
+   Bar.prop2
+----
 
 
 == License

--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionConfig.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionConfig.java
@@ -9,10 +9,13 @@ public class SwaggerAssertionConfig {
     private static final String PREFIX = "assertj.swagger.";
     private static final String IGNORE_MISSING_PATHS = "pathsToIgnoreInExpected";
     private static final String IGNORE_MISSING_DEFINITIONS = "definitionsToIgnoreInExpected";
+    private static final String IGNORE_MISSING_PROPERTIES = "propertiesToIgnoreInExpected";
 
     private Map<SwaggerAssertionType, Boolean> swaggerAssertionFlags = new HashMap<>();
 
     private Set<String> pathsToIgnoreInExpected = Collections.emptySet();
+
+    private Set<String> propertiesToIgnoreInExpected = Collections.emptySet();
 
     private Set<String> definitionsToIgnoreInExpected = Collections.emptySet();
 
@@ -42,12 +45,17 @@ public class SwaggerAssertionConfig {
 
         final String ignoreMissingPathsStr = props.getProperty(PREFIX + IGNORE_MISSING_PATHS);
         if (!StringUtils.isBlank(ignoreMissingPathsStr)) {
-            pathsToIgnoreInExpected = splitCommoaDelimStrIntoSet(ignoreMissingPathsStr);
+            pathsToIgnoreInExpected = splitCommaDelimStrIntoSet(ignoreMissingPathsStr);
         }
 
         final String ignoreMissingDefinitionsStr = props.getProperty(PREFIX + IGNORE_MISSING_DEFINITIONS);
         if (!StringUtils.isBlank(ignoreMissingDefinitionsStr)) {
-            definitionsToIgnoreInExpected = splitCommoaDelimStrIntoSet(ignoreMissingDefinitionsStr);
+            definitionsToIgnoreInExpected = splitCommaDelimStrIntoSet(ignoreMissingDefinitionsStr);
+        }
+
+        final String ignoreMissingPropertiesStr = props.getProperty(PREFIX + IGNORE_MISSING_PROPERTIES);
+        if (!StringUtils.isBlank(ignoreMissingPropertiesStr)) {
+            propertiesToIgnoreInExpected = splitCommaDelimStrIntoSet(ignoreMissingPropertiesStr);
         }
     }
 
@@ -64,9 +72,10 @@ public class SwaggerAssertionConfig {
         return definitionsToIgnoreInExpected;
     }
 
-    private Set<String> splitCommoaDelimStrIntoSet(String str) {
+    public Set<String> getPropertiesToIgnoreInExpected() { return propertiesToIgnoreInExpected; }
+
+    private Set<String> splitCommaDelimStrIntoSet(String str) {
         final String[] strs = str.split("\\s*,\\s*");
         return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(strs)));
     }
-
 }

--- a/src/test/java/io/github/robwin/swagger/SwaggerAssertTest.java
+++ b/src/test/java/io/github/robwin/swagger/SwaggerAssertTest.java
@@ -18,7 +18,10 @@
  */
 package io.github.robwin.swagger;
 
+import io.github.robwin.swagger.test.SwaggerAssert;
 import io.github.robwin.swagger.test.SwaggerAssertions;
+import io.swagger.parser.SwaggerParser;
+import org.apache.commons.lang3.Validate;
 import org.junit.Test;
 
 import java.io.File;
@@ -38,4 +41,15 @@ public class SwaggerAssertTest {
         File designFirstSwaggerLocation = new File(SwaggerAssertTest.class.getResource("/swagger.yaml").getPath());
         SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
+
+    @Test()
+    public void shouldHandlePartiallyImplementedApi(){
+        File implFirstSwaggerLocation = new File(SwaggerAssertTest.class.getResource("/partial_impl_swagger.json").getPath());
+        File designFirstSwaggerLocation = new File(SwaggerAssertTest.class.getResource("/swagger.yaml").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-partial-impl.properties")
+                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
 }

--- a/src/test/resources/assertj-swagger-partial-impl.properties
+++ b/src/test/resources/assertj-swagger-partial-impl.properties
@@ -1,0 +1,9 @@
+assertj.swagger.definitionsToIgnoreInExpected=User
+assertj.swagger.propertiesToIgnoreInExpected=Pet.photoUrls
+assertj.swagger.pathsToIgnoreInExpected=\
+   /users,\
+   /users/createWithArray,\
+   /users/createWithList,\
+   /users/login,\
+   /users/logout,\
+   /users/{username}

--- a/src/test/resources/partial_impl_swagger.json
+++ b/src/test/resources/partial_impl_swagger.json
@@ -1,0 +1,550 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "This is a sample server Petstore server.\n\n[Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.\n\nFor this sample, you can use the api key `special-key` to test the authorization filters\n",
+        "version": "1.0.0",
+        "title": "Swagger Petstore API",
+        "termsOfService": "http://helloreverb.com/terms/",
+        "contact": {
+            "name": "apiteam@wordnik.com"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        }
+    },
+    "host": "petstore.swagger.wordnik.com",
+    "basePath": "/v2",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/pets": {
+            "post": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Add a new pet to the store",
+                "description": "",
+                "operationId": "addPet",
+                "consumes": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Pet object that needs to be added to the store",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/definitions/Pet"
+                        }
+                    }
+                ],
+                "responses": {
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Update an existing pet",
+                "description": "",
+                "operationId": "updatePet",
+                "consumes": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Pet object that needs to be added to the store",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/definitions/Pet"
+                        }
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    },
+                    "405": {
+                        "description": "Validation exception"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/pets/findByStatus": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Finds Pets by status",
+                "description": "Multiple status values can be provided with comma seperated strings",
+                "operationId": "findPetsByStatus",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "status",
+                        "description": "Status values that need to be considered for filter",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid status value"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/pets/findByTags": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Finds Pets by tags",
+                "description": "Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.",
+                "operationId": "findPetsByTags",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "tags",
+                        "description": "Tags to filter by",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid tag value"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/pets/{petId}": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Find pet by ID",
+                "description": "Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions",
+                "operationId": "getPetById",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "petId",
+                        "description": "ID of pet that needs to be fetched",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Pet"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    },
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Updates a pet in the store with form data",
+                "description": "",
+                "operationId": "updatePetWithForm",
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "petId",
+                        "description": "ID of pet that needs to be updated",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "formData",
+                        "name": "name",
+                        "description": "Updated name of the pet",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "formData",
+                        "name": "status",
+                        "description": "Updated status of the pet",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Deletes a pet",
+                "description": "",
+                "operationId": "deletePet",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "header",
+                        "name": "api_key",
+                        "description": "",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "petId",
+                        "description": "Pet id to delete",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid pet value"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/stores/order": {
+            "post": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Place an order for a pet",
+                "description": "",
+                "operationId": "placeOrder",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "order placed for purchasing the pet",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid Order"
+                    }
+                }
+            }
+        },
+        "/stores/order/{orderId}": {
+            "get": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Find purchase order by ID",
+                "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
+                "operationId": "getOrderById",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "orderId",
+                        "description": "ID of pet that needs to be fetched",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Delete purchase order by ID",
+                "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+                "operationId": "deleteOrder",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "orderId",
+                        "description": "ID of the order that needs to be deleted",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                }
+            }
+        }
+    },
+    "securityDefinitions": {
+        "api_key": {
+            "type": "apiKey",
+            "name": "api_key",
+            "in": "header"
+        },
+        "petstore_auth": {
+            "type": "oauth2",
+            "authorizationUrl": "http://petstore.swagger.wordnik.com/api/oauth/dialog",
+            "flow": "implicit",
+            "scopes": {
+                "write_pets": "modify pets in your account",
+                "read_pets": "read your pets"
+            }
+        }
+    },
+    "definitions": {
+        "Category": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "Pet": {
+            "description" : "Test description",
+            "required": [
+                "name",
+                "photoUrls"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "category": {
+                    "$ref": "#/definitions/Category"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "doggie"
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    }
+                },
+                "status": {
+                    "type": "string",
+                    "description": "pet status in the store"
+                }
+            }
+        },
+        "Tag": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "Order": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "petId": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "quantity": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "shipDate": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Order Status"
+                },
+                "complete": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Robert,

I've added some additional test coverage, added support for whitelisting definition properties, and updated the documentation. I needed this change to work around a broken edge case in Springfox (that won't be in until 2.5.0 in June :-/), but felt it was more generally applicable.

Please let me know if there's anything which requires reworking or improving.

Cheers, Ben.