### PR TITLE
Implemented configuration setting: 'pathsPrependExpected'; info and version comparison

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -139,11 +139,11 @@ public void validateThatImplementationFitsDesignSpecification() throws Exception
 
 === Customizing assertj-swagger's behaviour
 
-For most use cases, the default behaviour will be sufficient.  However, you can override the default behaviour in various ways by placing a Java property file, `/assertj-swagger.properties`, at the root of your classpath.
+For most use cases, the default behaviour will be sufficient.  However, you can override the default behaviour in various ways by placing a Java property file, `/assertj-swagger.properties`, at the root of your classpath.  It is also possible to override the configuration in your tests; construct an instance of the `SwaggerAssert` class with a custom configuration if this is required.
 
 The following overrides are available:
 
-==== Disable various types of checks
+==== Disable various types of checks which are enabled by default
 
 * `assertj.swagger.validateDefinitions=false`: disable all validation of definitions
 ** `assertj.swagger.validateProperties=false`: disable validation of properties of definitions
@@ -152,6 +152,13 @@ The following overrides are available:
 *** `assertj.swagger.validateStringProperties=false`: disable validation of string properties of definitions
 ** `assertj.swagger.validateModels=false`: disable validation of models
 * `assertj.swagger.validatePaths=false`: disable all validation of endpoint definitions
+
+==== Enable various types of checks which are disabled by default
+
+The following settings are disabled by default, as they will cause schema comparisions to be too brittle for many users. They can be enabled if required.
+
+* `assertj.swagger.validateInfo=true`: enable comparison of the info section
+* `assertj.swagger.validateVersion=true`: enable comparison of the schema version numbers
 
 ==== Disable checks for certain paths or definitions in 'actual' schema
 

--- a/README.adoc
+++ b/README.adoc
@@ -185,6 +185,35 @@ assertj.swagger.propertiesToIgnoreInExpected=\
 ----
 
 
+==== Comparing expected and actual paths in schemas
+
+It is occasionally useful to be able to compare schemas, where due to limitations in tools and libraries, endpoint
+paths don't align. Specifying a `basePath` setting in your design-first schema here won't work -- it's only used by
+Swagger tooling to generate paths at runtime, and does *not* form part of the logical pathname of your endpoints.
+For instance, in your design-first schema, you may specify a set of endpoints and a `basePath`, while your generated
+schema (generated from, say, Springfox) has a common prefix prepended on the endpoint paths; e.g.:
+
+[source]
+----
+/pets/findByStatus       ! design-first schema
+----
+
+and
+
+[source]
+----
+/v2/pets/findByStatus    ! actual schema
+----
+
+To ensure that assertj-swagger is comparing like-with-like in this situation, you could use the following in your
+configuration file:
+
+[source]
+----
+assertj.swagger.pathsPrependExpected=/v2
+----
+
+
 == License
 
 Copyright 2015 Robert Winkler

--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
@@ -96,6 +96,9 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
     }
 
     private void validateSwagger(Swagger expected) {
+
+        validateInfo(actual.getInfo(), expected.getInfo());
+
         // Check Paths
         if (isAssertionEnabled(SwaggerAssertionType.PATHS)) {
             final Set<String> filter = assertionConfig.getPathsToIgnoreInExpected();
@@ -110,6 +113,19 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
         }
 
         softAssertions.assertAll();
+    }
+
+    private void validateInfo(Info actualInfo, Info expectedInfo) {
+
+        // Version.  OFF by default.
+        if (isAssertionEnabled(SwaggerAssertionType.VERSION)) {
+            softAssertions.assertThat(actualInfo.getVersion()).as("Checking Version").isEqualTo(expectedInfo.getVersion());
+        }
+
+        // Everything (but potentially brittle, therefore OFF by default)
+        if (isAssertionEnabled(SwaggerAssertionType.INFO)) {
+            softAssertions.assertThat(actualInfo).as("Checking Info").isEqualToComparingFieldByField(expectedInfo);
+        }
     }
 
     private void validatePaths(Map<String, Path> actualPaths, Map<String, Path> expectedPaths) {

--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
@@ -27,6 +27,7 @@ import io.swagger.models.properties.StringProperty;
 import io.swagger.parser.SwaggerParser;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.SoftAssertions;
 
@@ -98,7 +99,8 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
         // Check Paths
         if (isAssertionEnabled(SwaggerAssertionType.PATHS)) {
             final Set<String> filter = assertionConfig.getPathsToIgnoreInExpected();
-            validatePaths(actual.getPaths(), removeAllFromMap(expected.getPaths(), filter));
+            final Map<String, Path> expectedPaths = adjustExpectedPathsWithPrefix(expected.getPaths(), assertionConfig.getPathsPrependExpected());
+            validatePaths(actual.getPaths(), removeAllFromMap(expectedPaths, filter));
         }
 
         // Check Definitions
@@ -422,8 +424,7 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
     private Set<String> filterWhitelistedPropertyNames(String definitionName, Set<String> expectedPropertyNames) {
         Set<String> result = new HashSet<>(expectedPropertyNames.size());
         final Set<String> ignoredPropertyNames = assertionConfig.getPropertiesToIgnoreInExpected();
-        for (Iterator<String> i = expectedPropertyNames.iterator(); i.hasNext(); ) {
-            String property = i.next();
+        for (String property : expectedPropertyNames) {
             if (!ignoredPropertyNames.contains(definitionName + '.' + property)) {
                 result.add(property);
             }
@@ -436,6 +437,19 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
         result.keySet().removeAll(keysToExclude);
         return result;
     }
+
+    private Map<String, Path> adjustExpectedPathsWithPrefix(Map<String, Path> paths, String prefix) {
+        if (StringUtils.isBlank(prefix)) {
+            return paths;   // no path prefix configured, nothing to do
+        }
+
+        final Map<String, Path> adjustedPaths = new HashMap<>(paths.size());
+        for (final Map.Entry<String, Path> entry : paths.entrySet()) {
+            adjustedPaths.put(prefix + entry.getKey(), entry.getValue());
+        }
+        return adjustedPaths;
+    }
+
 
     /**
      * Provide a means to retrieve values from various objects in the schema, providing a fallback to 'global'
@@ -474,7 +488,7 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
             } else if (globalDefn != null) {
                 result = globalDefn;
             } else {
-                result = Collections.<A>emptyList();
+                result = Collections.emptyList();
             }
             return result;
         }

--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionConfig.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionConfig.java
@@ -24,12 +24,12 @@ public class SwaggerAssertionConfig {
 
 
     /**
-     * Construct a {@link SwaggerAssertionConfig}.  All checks are enabled by default.
+     * Construct a {@link SwaggerAssertionConfig}.
      */
     public SwaggerAssertionConfig() {
         final SwaggerAssertionType[] assertionTypes = SwaggerAssertionType.values();
         for (final SwaggerAssertionType assertionType : assertionTypes) {
-            swaggerAssertionFlags.put(assertionType, Boolean.TRUE);
+            swaggerAssertionFlags.put(assertionType, assertionType.isEnabledByDefault());
         }
     }
 
@@ -43,7 +43,11 @@ public class SwaggerAssertionConfig {
         final SwaggerAssertionType[] assertionTypes = SwaggerAssertionType.values();
         for (final SwaggerAssertionType assertionType : assertionTypes) {
             final String value = props.getProperty(PREFIX + assertionType.getBarePropertyName());
-            swaggerAssertionFlags.put(assertionType, (value == null) || Boolean.TRUE.toString().equals(value));
+            if (value != null) {
+                swaggerAssertionFlags.put(assertionType, Boolean.TRUE.toString().equals(value));
+            } else {
+                swaggerAssertionFlags.put(assertionType, assertionType.isEnabledByDefault());
+            }
         }
 
         final String ignoreMissingPathsStr = props.getProperty(PREFIX + IGNORE_MISSING_PATHS);
@@ -66,7 +70,7 @@ public class SwaggerAssertionConfig {
 
     public boolean swaggerAssertionEnabled(SwaggerAssertionType assertionType) {
         final Boolean flag = swaggerAssertionFlags.get(assertionType);
-        return (flag != null ? flag : true);    // turn ON all checks by default
+        return (flag != null ? flag : assertionType.isEnabledByDefault());
     }
 
     public Set<String> getPathsToIgnoreInExpected() {

--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionConfig.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionConfig.java
@@ -10,6 +10,7 @@ public class SwaggerAssertionConfig {
     private static final String IGNORE_MISSING_PATHS = "pathsToIgnoreInExpected";
     private static final String IGNORE_MISSING_DEFINITIONS = "definitionsToIgnoreInExpected";
     private static final String IGNORE_MISSING_PROPERTIES = "propertiesToIgnoreInExpected";
+    private static final String PATHS_PREPEND_EXPECTED = "pathsPrependExpected";
 
     private Map<SwaggerAssertionType, Boolean> swaggerAssertionFlags = new HashMap<>();
 
@@ -18,6 +19,8 @@ public class SwaggerAssertionConfig {
     private Set<String> propertiesToIgnoreInExpected = Collections.emptySet();
 
     private Set<String> definitionsToIgnoreInExpected = Collections.emptySet();
+
+    private String pathsPrependExpected;
 
 
     /**
@@ -57,6 +60,8 @@ public class SwaggerAssertionConfig {
         if (!StringUtils.isBlank(ignoreMissingPropertiesStr)) {
             propertiesToIgnoreInExpected = splitCommaDelimStrIntoSet(ignoreMissingPropertiesStr);
         }
+
+        pathsPrependExpected = props.getProperty(PREFIX + PATHS_PREPEND_EXPECTED);
     }
 
     public boolean swaggerAssertionEnabled(SwaggerAssertionType assertionType) {
@@ -73,6 +78,10 @@ public class SwaggerAssertionConfig {
     }
 
     public Set<String> getPropertiesToIgnoreInExpected() { return propertiesToIgnoreInExpected; }
+
+    public String getPathsPrependExpected() {
+        return pathsPrependExpected;
+    }
 
     private Set<String> splitCommaDelimStrIntoSet(String str) {
         final String[] strs = str.split("\\s*,\\s*");

--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionType.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionType.java
@@ -5,22 +5,30 @@ package io.github.robwin.swagger.test;
  */
 public enum SwaggerAssertionType {
 
-    DEFINITIONS("validateDefinitions"),
-        PROPERTIES("validateProperties"),
-            REF_PROPERTIES("validateRefProperties"),
-            ARRAY_PROPERTIES("validateArrayProperties"),
-            STRING_PROPERTIES("validateStringProperties"),
-        MODELS("validateModels"),
-    PATHS("validatePaths");
+    INFO("validateInfo", false),
+    VERSION("validateVersion", false),
+
+    DEFINITIONS("validateDefinitions", true),
+        PROPERTIES("validateProperties", true),
+            REF_PROPERTIES("validateRefProperties", true),
+            ARRAY_PROPERTIES("validateArrayProperties", true),
+            STRING_PROPERTIES("validateStringProperties", true),
+        MODELS("validateModels", true),
+    PATHS("validatePaths", true);
 
     private String suffix;
+    private boolean enabledByDefault;
 
-    SwaggerAssertionType(final String assertionType) {
+    SwaggerAssertionType(final String assertionType, final boolean defaultValue) {
         this.suffix = assertionType;
+        this.enabledByDefault = defaultValue;
     }
 
     public String getBarePropertyName() {
         return suffix;
     }
 
+    public boolean isEnabledByDefault() {
+        return enabledByDefault;
+    }
 }

--- a/src/test/java/io/github/robwin/swagger/SwaggerAssertTest.java
+++ b/src/test/java/io/github/robwin/swagger/SwaggerAssertTest.java
@@ -52,4 +52,14 @@ public class SwaggerAssertTest {
                 .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
+    @Test()
+    public void shouldHandleExpectedPathsWithPrefix(){
+        File implFirstSwaggerLocation = new File(SwaggerAssertTest.class.getResource("/swagger_with_path_prefixes.json").getPath());
+        File designFirstSwaggerLocation = new File(SwaggerAssertTest.class.getResource("/swagger.yaml").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-path-prefix.properties")
+                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
 }

--- a/src/test/java/io/github/robwin/swagger/SwaggerAssertTest.java
+++ b/src/test/java/io/github/robwin/swagger/SwaggerAssertTest.java
@@ -42,6 +42,15 @@ public class SwaggerAssertTest {
         SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
+    @Test(expected = AssertionError.class)
+    public void shouldFindDifferencesInInfo(){
+        // Otherwise-good comparison will fail here, because 'info.title' is different
+        File implFirstSwaggerLocation = new File(SwaggerAssertTest.class.getResource("/swagger.json").getPath());
+        File designFirstSwaggerLocation = new File(SwaggerAssertTest.class.getResource("/swagger.yaml").getPath());
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-info.properties")
+                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
     @Test()
     public void shouldHandlePartiallyImplementedApi(){
         File implFirstSwaggerLocation = new File(SwaggerAssertTest.class.getResource("/partial_impl_swagger.json").getPath());

--- a/src/test/resources/assertj-swagger-info.properties
+++ b/src/test/resources/assertj-swagger-info.properties
@@ -1,0 +1,1 @@
+assertj.swagger.validateInfo=true

--- a/src/test/resources/assertj-swagger-path-prefix.properties
+++ b/src/test/resources/assertj-swagger-path-prefix.properties
@@ -1,0 +1,1 @@
+assertj.swagger.pathsPrependExpected=/v2

--- a/src/test/resources/swagger_with_path_prefixes.json
+++ b/src/test/resources/swagger_with_path_prefixes.json
@@ -1,0 +1,846 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "This is a sample server Petstore server.\n\n[Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.\n\nFor this sample, you can use the api key `special-key` to test the authorization filters\n",
+        "version": "1.0.0",
+        "title": "Swagger Petstore API",
+        "termsOfService": "http://helloreverb.com/terms/",
+        "contact": {
+            "name": "apiteam@wordnik.com"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        }
+    },
+    "host": "petstore.swagger.wordnik.com",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/v2/pets": {
+            "post": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Add a new pet to the store",
+                "description": "",
+                "operationId": "addPet",
+                "consumes": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Pet object that needs to be added to the store",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/definitions/Pet"
+                        }
+                    }
+                ],
+                "responses": {
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Update an existing pet",
+                "description": "",
+                "operationId": "updatePet",
+                "consumes": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Pet object that needs to be added to the store",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/definitions/Pet"
+                        }
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    },
+                    "405": {
+                        "description": "Validation exception"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/v2/pets/findByStatus": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Finds Pets by status",
+                "description": "Multiple status values can be provided with comma seperated strings",
+                "operationId": "findPetsByStatus",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "status",
+                        "description": "Status values that need to be considered for filter",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid status value"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/v2/pets/findByTags": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Finds Pets by tags",
+                "description": "Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.",
+                "operationId": "findPetsByTags",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "tags",
+                        "description": "Tags to filter by",
+                        "required": false,
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid tag value"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/v2/pets/{petId}": {
+            "get": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Find pet by ID",
+                "description": "Returns a pet when ID < 10.  ID > 10 or nonintegers will simulate API error conditions",
+                "operationId": "getPetById",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "petId",
+                        "description": "ID of pet that needs to be fetched",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Pet"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Pet not found"
+                    }
+                },
+                "security": [
+                    {
+                        "api_key": []
+                    },
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Updates a pet in the store with form data",
+                "description": "",
+                "operationId": "updatePetWithForm",
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "petId",
+                        "description": "ID of pet that needs to be updated",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "formData",
+                        "name": "name",
+                        "description": "Updated name of the pet",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "formData",
+                        "name": "status",
+                        "description": "Updated status of the pet",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "405": {
+                        "description": "Invalid input"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "pet"
+                ],
+                "summary": "Deletes a pet",
+                "description": "",
+                "operationId": "deletePet",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "header",
+                        "name": "api_key",
+                        "description": "",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "path",
+                        "name": "petId",
+                        "description": "Pet id to delete",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid pet value"
+                    }
+                },
+                "security": [
+                    {
+                        "petstore_auth": [
+                            "write_pets",
+                            "read_pets"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/v2/stores/order": {
+            "post": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Place an order for a pet",
+                "description": "",
+                "operationId": "placeOrder",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "order placed for purchasing the pet",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid Order"
+                    }
+                }
+            }
+        },
+        "/v2/stores/order/{orderId}": {
+            "get": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Find purchase order by ID",
+                "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions",
+                "operationId": "getOrderById",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "orderId",
+                        "description": "ID of pet that needs to be fetched",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Order"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "store"
+                ],
+                "summary": "Delete purchase order by ID",
+                "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+                "operationId": "deleteOrder",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "orderId",
+                        "description": "ID of the order that needs to be deleted",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid ID supplied"
+                    },
+                    "404": {
+                        "description": "Order not found"
+                    }
+                }
+            }
+        },
+        "/v2/users": {
+            "post": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Create user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "createUser",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Created user object",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/definitions/User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            }
+        },
+        "/v2/users/createWithArray": {
+            "post": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Creates list of users with given input array",
+                "description": "",
+                "operationId": "createUsersWithArrayInput",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "List of user object",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/User"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            }
+        },
+        "/v2/users/createWithList": {
+            "post": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Creates list of users with given input array",
+                "description": "",
+                "operationId": "createUsersWithListInput",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "List of user object",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/User"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            }
+        },
+        "/v2/users/login": {
+            "get": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Logs user into the system",
+                "description": "",
+                "operationId": "loginUser",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "username",
+                        "description": "The user name for login",
+                        "required": false,
+                        "type": "string"
+                    },
+                    {
+                        "in": "query",
+                        "name": "password",
+                        "description": "The password for login in clear text",
+                        "required": false,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid username/password supplied"
+                    }
+                }
+            }
+        },
+        "/v2/users/logout": {
+            "get": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Logs out current logged in user session",
+                "description": "",
+                "operationId": "logoutUser",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "responses": {
+                    "default": {
+                        "description": "successful operation"
+                    }
+                }
+            }
+        },
+        "/v2/users/{username}": {
+            "get": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Get user by user name",
+                "description": "",
+                "operationId": "getUserByName",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "username",
+                        "description": "The name that needs to be fetched. Use user1 for testing.",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/User"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid username supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Updated user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "updateUser",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "username",
+                        "description": "name that need to be deleted",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "in": "body",
+                        "name": "body",
+                        "description": "Updated user object",
+                        "required": false,
+                        "schema": {
+                            "$ref": "#/definitions/User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid user supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "user"
+                ],
+                "summary": "Delete user",
+                "description": "This can only be done by the logged in user.",
+                "operationId": "deleteUser",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "username",
+                        "description": "The name that needs to be deleted",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "400": {
+                        "description": "Invalid username supplied"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    }
+                }
+            }
+        }
+    },
+    "securityDefinitions": {
+        "api_key": {
+            "type": "apiKey",
+            "name": "api_key",
+            "in": "header"
+        },
+        "petstore_auth": {
+            "type": "oauth2",
+            "authorizationUrl": "http://petstore.swagger.wordnik.com/api/oauth/dialog",
+            "flow": "implicit",
+            "scopes": {
+                "write_pets": "modify pets in your account",
+                "read_pets": "read your pets"
+            }
+        }
+    },
+    "definitions": {
+        "User": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                },
+                "phone": {
+                    "type": "string"
+                },
+                "userStatus": {
+                    "type": "integer",
+                    "format": "int32",
+                    "description": "User Status"
+                }
+            }
+        },
+        "Category": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "Pet": {
+            "description" : "Test description",
+            "required": [
+                "name",
+                "photoUrls"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "category": {
+                    "$ref": "#/definitions/Category"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "doggie"
+                },
+                "photoUrls": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tags": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Tag"
+                    }
+                },
+                "status": {
+                    "type": "string",
+                    "description": "pet status in the store"
+                }
+            }
+        },
+        "Tag": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "Order": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "petId": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "quantity": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "shipDate": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Order Status"
+                },
+                "complete": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added configuration setting to permit specifying a prefix for paths in design-first schema. Needed this to make it easier to compare against Springfox-generated schemas.

Added optional checks to enforce version number parity. Also, it is now possible to turn on strict comparison of the entire Info block.

Added tests.