### PR TITLE
Make assertj-swagger "allOf"-aware

### DIFF
--- a/src/main/java/io/github/robwin/swagger/test/ConsumerDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/ConsumerDrivenValidator.java
@@ -16,11 +16,10 @@ import java.util.*;
 /**
  * Created by raceconditions on 3/17/16.
  */
-public class ConsumerDrivenValidator implements ContractValidator {
+class ConsumerDrivenValidator implements ContractValidator {
 
     private SoftAssertions softAssertions;
 
-    private static final String ASSERTION_ENABLED_CONFIG_PATH = "/assertj-swagger.properties";
     private SwaggerAssertionConfig assertionConfig;
     private Swagger actual;
     private SchemaObjectResolver schemaObjectResolver;   // provide means to fall back from local to global properties
@@ -116,7 +115,9 @@ public class ConsumerDrivenValidator implements ContractValidator {
     private void validateDefinition(String definitionName, Model actualDefinition, Model expectedDefinition) {
         if (expectedDefinition != null && actualDefinition != null) {
             validateModel(actualDefinition, expectedDefinition, String.format("Checking model of definition '%s", definitionName));
-            validateDefinitionProperties(actualDefinition.getProperties(), expectedDefinition.getProperties(), definitionName);
+            validateDefinitionProperties(schemaObjectResolver.resolvePropertiesFromActual(actualDefinition),
+                                         schemaObjectResolver.resolvePropertiesFromExpected(expectedDefinition),
+                                         definitionName);
         }
     }
 

--- a/src/main/java/io/github/robwin/swagger/test/ConsumerDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/ConsumerDrivenValidator.java
@@ -23,7 +23,7 @@ public class ConsumerDrivenValidator implements ContractValidator {
     private static final String ASSERTION_ENABLED_CONFIG_PATH = "/assertj-swagger.properties";
     private SwaggerAssertionConfig assertionConfig;
     private Swagger actual;
-    private AttributeResolver attributeResolver;   // provide means to fall back from local to global properties
+    private SchemaObjectResolver schemaObjectResolver;   // provide means to fall back from local to global properties
 
     ConsumerDrivenValidator(Swagger actual, SwaggerAssertionConfig assertionConfig) {
         this.actual = actual;
@@ -32,8 +32,8 @@ public class ConsumerDrivenValidator implements ContractValidator {
     }
 
     @Override
-    public void validateSwagger(Swagger expected, AttributeResolver attributeResolver) {
-        this.attributeResolver = attributeResolver;
+    public void validateSwagger(Swagger expected, SchemaObjectResolver schemaObjectResolver) {
+        this.schemaObjectResolver = schemaObjectResolver;
 
         validateInfo(actual.getInfo(), expected.getInfo());
 
@@ -201,12 +201,12 @@ public class ConsumerDrivenValidator implements ContractValidator {
             softAssertions.assertThat(actualOperation).as(message).isNotNull();
             if(actualOperation != null) {
                 //Validate consumes
-                validateList(attributeResolver.getActualConsumes(actualOperation),
-                        attributeResolver.getExpectedConsumes((expectedOperation)),
+                validateList(schemaObjectResolver.getActualConsumes(actualOperation),
+                        schemaObjectResolver.getExpectedConsumes((expectedOperation)),
                         String.format("Checking '%s' of '%s' operation of path '%s'", "consumes", httpMethod, path));
                 //Validate produces
-                validateList(attributeResolver.getActualProduces(actualOperation),
-                        attributeResolver.getExpectedProduces((expectedOperation)),
+                validateList(schemaObjectResolver.getActualProduces(actualOperation),
+                        schemaObjectResolver.getExpectedProduces((expectedOperation)),
                         String.format("Checking '%s' of '%s' operation of path '%s'", "produces", httpMethod, path));
                 //Validate parameters
                 validateParameters(actualOperation.getParameters(), expectedOperation.getParameters(), httpMethod, path);

--- a/src/main/java/io/github/robwin/swagger/test/ContractValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/ContractValidator.java
@@ -3,5 +3,5 @@ package io.github.robwin.swagger.test;
 import io.swagger.models.Swagger;
 
 public interface ContractValidator {
-    void validateSwagger(Swagger expected, AttributeResolver attributeResolver);
+    void validateSwagger(Swagger expected, SchemaObjectResolver schemaObjectResolver);
 }

--- a/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
@@ -17,7 +17,6 @@ class DocumentationDrivenValidator implements ContractValidator {
 
     private SoftAssertions softAssertions;
 
-    private static final String ASSERTION_ENABLED_CONFIG_PATH = "/assertj-swagger.properties";
     private SwaggerAssertionConfig assertionConfig;
     private Swagger actual;
     private SchemaObjectResolver schemaObjectResolver;   // provide means to fall back from local to global properties
@@ -111,7 +110,9 @@ class DocumentationDrivenValidator implements ContractValidator {
     private void validateDefinition(String definitionName, Model actualDefinition, Model expectedDefinition) {
         if (expectedDefinition != null) {
             validateModel(actualDefinition, expectedDefinition, String.format("Checking model of definition '%s", definitionName));
-            validateDefinitionProperties(actualDefinition.getProperties(), expectedDefinition.getProperties(), definitionName);
+            validateDefinitionProperties(schemaObjectResolver.resolvePropertiesFromActual(actualDefinition),
+                                         schemaObjectResolver.resolvePropertiesFromExpected(expectedDefinition),
+                                         definitionName);
         }
     }
 

--- a/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
@@ -20,7 +20,7 @@ class DocumentationDrivenValidator implements ContractValidator {
     private static final String ASSERTION_ENABLED_CONFIG_PATH = "/assertj-swagger.properties";
     private SwaggerAssertionConfig assertionConfig;
     private Swagger actual;
-    private AttributeResolver attributeResolver;   // provide means to fall back from local to global properties
+    private SchemaObjectResolver schemaObjectResolver;   // provide means to fall back from local to global properties
 
     DocumentationDrivenValidator(Swagger actual, SwaggerAssertionConfig assertionConfig) {
         this.actual = actual;
@@ -28,8 +28,8 @@ class DocumentationDrivenValidator implements ContractValidator {
         softAssertions = new SoftAssertions();
     }
 
-    public void validateSwagger(Swagger expected, AttributeResolver attributeResolver) {
-        this.attributeResolver = attributeResolver;
+    public void validateSwagger(Swagger expected, SchemaObjectResolver schemaObjectResolver) {
+        this.schemaObjectResolver = schemaObjectResolver;
 
         validateInfo(actual.getInfo(), expected.getInfo());
 
@@ -196,12 +196,12 @@ class DocumentationDrivenValidator implements ContractValidator {
             softAssertions.assertThat(actualOperation).as(message).isNotNull();
             if(actualOperation != null) {
                 //Validate consumes
-                validateList(attributeResolver.getActualConsumes(actualOperation),
-                        attributeResolver.getExpectedConsumes((expectedOperation)),
+                validateList(schemaObjectResolver.getActualConsumes(actualOperation),
+                        schemaObjectResolver.getExpectedConsumes((expectedOperation)),
                         String.format("Checking '%s' of '%s' operation of path '%s'", "consumes", httpMethod, path));
                 //Validate produces
-                validateList(attributeResolver.getActualProduces(actualOperation),
-                        attributeResolver.getExpectedProduces((expectedOperation)),
+                validateList(schemaObjectResolver.getActualProduces(actualOperation),
+                        schemaObjectResolver.getExpectedProduces((expectedOperation)),
                         String.format("Checking '%s' of '%s' operation of path '%s'", "produces", httpMethod, path));
                 //Validate parameters
                 validateParameters(actualOperation.getParameters(), expectedOperation.getParameters(), httpMethod, path);

--- a/src/main/java/io/github/robwin/swagger/test/SchemaObjectResolver.java
+++ b/src/main/java/io/github/robwin/swagger/test/SchemaObjectResolver.java
@@ -7,32 +7,33 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Provide a means to retrieve values from various objects in the schema, providing a fallback to 'global'
- * settings if they're not defined locally.
+ * Provide a means to retrieve values from various objects in the schema.  Provides a means of falling back to 'global'
+ * settings if they're not defined locally in a definition or path object.  Also permits resolving local
+ * {@code $ref}-erences and types making use of {@code allOf}-style inheritance.
  */
-class AttributeResolver {
+class SchemaObjectResolver {
 
     private Swagger expected;
     private Swagger actual;
 
-    public AttributeResolver(Swagger expected, Swagger actual) {
+    SchemaObjectResolver(Swagger expected, Swagger actual) {
         this.expected = expected;
         this.actual = actual;
     }
 
-    public List<String> getExpectedConsumes(Operation op) {
+    List<String> getExpectedConsumes(Operation op) {
         return getListWithFallback(op.getConsumes(), expected.getConsumes());
     }
 
-    public List<String> getActualConsumes(Operation op) {
+    List<String> getActualConsumes(Operation op) {
         return getListWithFallback(op.getConsumes(), actual.getConsumes());
     }
 
-    public List<String> getExpectedProduces(Operation op) {
+    List<String> getExpectedProduces(Operation op) {
         return getListWithFallback(op.getProduces(), expected.getProduces());
     }
 
-    public List<String> getActualProduces(Operation op) {
+    List<String> getActualProduces(Operation op) {
         return getListWithFallback(op.getProduces(), actual.getProduces());
     }
 
@@ -49,3 +50,4 @@ class AttributeResolver {
     }
 
 }
+

--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
@@ -69,8 +69,8 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
      * @throws AssertionError if the actual value is not equal to the given one or if the actual value is {@code null}..
      */
     public SwaggerAssert isEqualTo(Swagger expected) {
-        AttributeResolver attributeResolver = new AttributeResolver(expected, actual);
-        documentationDrivenValidator.validateSwagger(expected, attributeResolver);
+        SchemaObjectResolver schemaObjectResolver = new SchemaObjectResolver(expected, actual);
+        documentationDrivenValidator.validateSwagger(expected, schemaObjectResolver);
         return myself;
     }
 
@@ -93,8 +93,8 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
      * @throws AssertionError if the actual value is not equal to the given one or if the actual value is {@code null}..
      */
     public SwaggerAssert satisfiesContract(Swagger expected) {
-        AttributeResolver attributeResolver = new AttributeResolver(expected, actual);
-        consumerDrivenValidator.validateSwagger(expected, attributeResolver);
+        SchemaObjectResolver schemaObjectResolver = new SchemaObjectResolver(expected, actual);
+        consumerDrivenValidator.validateSwagger(expected, schemaObjectResolver);
         return myself;
     }
 

--- a/src/test/java/io/github/robwin/swagger/SwaggerConsumerDrivenAssertTest.java
+++ b/src/test/java/io/github/robwin/swagger/SwaggerConsumerDrivenAssertTest.java
@@ -29,21 +29,21 @@ import java.io.File;
 public class SwaggerConsumerDrivenAssertTest {
 
     @Test
-    public void shouldFindNoDifferences(){
+    public void shouldFindNoDifferences() {
         File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.json").getFile());
         File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.yaml").getFile());
         SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).satisfiesContract(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
-    public void shouldFindDifferencesInImplementation(){
+    public void shouldFindDifferencesInImplementation() {
         File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/wrong_swagger.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
         SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).satisfiesContract(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
-    public void shouldFindDifferencesInInfo(){
+    public void shouldFindDifferencesInInfo() {
         // Otherwise-good comparison will fail here, because 'info.title' is different
         File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
@@ -52,7 +52,7 @@ public class SwaggerConsumerDrivenAssertTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void shouldFindMissingPropertyInPartialModel(){
+    public void shouldFindMissingPropertyInPartialModel() {
         File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-singleresource-extraproperty.json").getPath());
 
@@ -61,7 +61,7 @@ public class SwaggerConsumerDrivenAssertTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void shouldFindMissingMethodInPartialModel(){
+    public void shouldFindMissingMethodInPartialModel() {
         File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-singleresource-extramethod.json").getPath());
 
@@ -70,7 +70,7 @@ public class SwaggerConsumerDrivenAssertTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void shouldFindMissingResourceInPartialModel(){
+    public void shouldFindMissingResourceInPartialModel() {
         File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-extraresource.json").getPath());
 
@@ -78,8 +78,8 @@ public class SwaggerConsumerDrivenAssertTest {
         SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).satisfiesContract(designFirstSwaggerLocation.getAbsolutePath());
     }
 
-    @Test()
-    public void shouldHandleConsumerContractSingleResource(){
+    @Test
+    public void shouldHandleConsumerContractSingleResource() {
         File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-singleresource.json").getPath());
 
@@ -87,8 +87,8 @@ public class SwaggerConsumerDrivenAssertTest {
         SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).satisfiesContract(designFirstSwaggerLocation.getAbsolutePath());
     }
 
-    @Test()
-    public void shouldHandleConsumerContractPartialModel(){
+    @Test
+    public void shouldHandleConsumerContractPartialModel() {
         File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-singleresource-partialmodel.json").getPath());
 
@@ -96,14 +96,34 @@ public class SwaggerConsumerDrivenAssertTest {
         SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).satisfiesContract(designFirstSwaggerLocation.getAbsolutePath());
     }
 
-    @Test()
-    public void shouldHandleExpectedPathsWithPrefix(){
+    @Test
+    public void shouldHandleExpectedPathsWithPrefix() {
         File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger_with_path_prefixes.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
 
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-path-prefix.properties")
                 .satisfiesContract(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
+    @Test
+    public void shouldHandleDefinitionsUsingAllOf() {
+        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-flat.json").getPath());
+        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-inheritance.json").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-allOf.properties")
+            .satisfiesContract(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
+    @Test
+    public void shouldHandleDefinitionsUsingAllOfIncludingCycles() {
+        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-flat.json").getPath());
+        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-inheritance-cycles.json").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-allOf.properties")
+            .satisfiesContract(designFirstSwaggerLocation.getAbsolutePath());
     }
 
 }

--- a/src/test/java/io/github/robwin/swagger/SwaggerDocumentationDrivenAssertTest.java
+++ b/src/test/java/io/github/robwin/swagger/SwaggerDocumentationDrivenAssertTest.java
@@ -71,4 +71,24 @@ public class SwaggerDocumentationDrivenAssertTest {
                 .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
+    @Test
+    public void shouldHandleDefinitionsUsingAllOf() {
+        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-flat.json").getPath());
+        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-inheritance.json").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-allOf.properties")
+                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
+    @Test
+    public void shouldHandleDefinitionsUsingAllOfIncludingCycles() {
+        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-flat.json").getPath());
+        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-inheritance-cycles.json").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-allOf.properties")
+                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
 }

--- a/src/test/resources/assertj-swagger-allOf.properties
+++ b/src/test/resources/assertj-swagger-allOf.properties
@@ -1,0 +1,2 @@
+assertj.swagger.validateModels=false
+assertj.swagger.definitionsToIgnoreInExpected=AbstractOrder,Order1,Order2

--- a/src/test/resources/swagger-allOf-test-flat.json
+++ b/src/test/resources/swagger-allOf-test-flat.json
@@ -1,0 +1,42 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore API"
+    },
+    "paths": {
+    },
+    "definitions": {
+        "Order": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "petId": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "quantity": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "shipDate": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Order Status"
+                },
+                "complete": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "id"
+            ]
+        }
+    }
+}

--- a/src/test/resources/swagger-allOf-test-inheritance-cycles.json
+++ b/src/test/resources/swagger-allOf-test-inheritance-cycles.json
@@ -1,0 +1,74 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore API"
+    },
+    "paths": {
+    },
+    "definitions": {
+        "AbstractOrder": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            },
+            "required": [
+                "id"
+            ]
+        },
+        "Order": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/AbstractOrder"
+                },
+                {
+                    "$ref": "#/definitions/Order1"
+                }
+            ]
+        },
+        "Order1": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Order2"
+                },
+                {
+                    "properties": {
+                        "petId": {
+                            "type": "integer",
+                            "format": "int64"
+                        }
+                    }
+                }
+            ]
+        },
+        "Order2": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Order1"
+                },
+                {
+                    "properties": {
+                        "quantity": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "shipDate": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string",
+                            "description": "Order Status"
+                        },
+                        "complete": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/src/test/resources/swagger-allOf-test-inheritance.json
+++ b/src/test/resources/swagger-allOf-test-inheritance.json
@@ -1,0 +1,53 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore API"
+    },
+    "paths": {
+    },
+    "definitions": {
+        "AbstractOrder": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            },
+            "required": [
+                "id"
+            ]
+        },
+        "Order": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/AbstractOrder"
+                },
+                {
+                    "properties": {
+                        "petId": {
+                            "type": "integer",
+                            "format": "int64"
+                        },
+                        "quantity": {
+                            "type": "integer",
+                            "format": "int32"
+                        },
+                        "shipDate": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string",
+                            "description": "Order Status"
+                        },
+                        "complete": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for comparing schemas which contain definitions, where one or both schemas under comparison are composed using the `allOf` keyword.