### PR TITLE
Fix documentation driven validation regarding the usage of allOf's for composition.

### DIFF
--- a/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
@@ -27,7 +27,8 @@ class DocumentationDrivenValidator implements ContractValidator {
         softAssertions = new SoftAssertions();
     }
 
-    public void validateSwagger(Swagger expected, SchemaObjectResolver schemaObjectResolver) {
+    @Override
+	public void validateSwagger(Swagger expected, SchemaObjectResolver schemaObjectResolver) {
         this.schemaObjectResolver = schemaObjectResolver;
 
         validateInfo(actual.getInfo(), expected.getInfo());
@@ -128,7 +129,10 @@ class DocumentationDrivenValidator implements ContractValidator {
                 ArrayModel arrayModel = ((ArrayModel) expectedDefinition);
                 // TODO Validate ArrayModel
                 softAssertions.assertThat(actualDefinition).as(message).isExactlyInstanceOf(ArrayModel.class);
-            }else{
+            } else if (expectedDefinition instanceof ComposedModel) {
+                ComposedModel composedModel = (ComposedModel) expectedDefinition;
+                softAssertions.assertThat(actualDefinition).as(message).isInstanceOfAny(ComposedModel.class, ModelImpl.class);
+            } else{
                 // TODO Validate all model types
                 softAssertions.assertThat(actualDefinition).isExactlyInstanceOf(expectedDefinition.getClass());
             }

--- a/src/test/java/io/github/robwin/swagger/SwaggerDocumentationDrivenAssertTest.java
+++ b/src/test/java/io/github/robwin/swagger/SwaggerDocumentationDrivenAssertTest.java
@@ -104,5 +104,15 @@ public class SwaggerDocumentationDrivenAssertTest {
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-allOf.properties")
                 .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
-
+    
+    @Test
+    public void shouldHandleDefinitionsUsingAllOfForComposition() {
+        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-composition-flat.json").getPath());
+        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-composition.json").getPath());
+        
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
+                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+    }
+    
 }

--- a/src/test/resources/swagger-allOf-composition-flat.json
+++ b/src/test/resources/swagger-allOf-composition-flat.json
@@ -1,0 +1,53 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore API"
+    },
+    "paths": {
+    },
+    "definitions": {
+        "Id": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            }
+        },
+        "AuditLog": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "modified": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "Item": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "created": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "modified": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/swagger-allOf-composition.json
+++ b/src/test/resources/swagger-allOf-composition.json
@@ -1,0 +1,51 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore API"
+    },
+    "paths": {
+    },
+    "definitions": {
+        "Id": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                }
+            }
+        },
+        "AuditLog": {
+            "type": "object",
+            "properties": {
+                "created": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "modified": {
+                    "type": "string",
+                    "format": "date-time"
+                }
+            }
+        },
+        "Item": {
+            "type": "object",
+            "allOf": [
+                {
+                    "$ref": "#/definitions/Id"
+                },
+                {
+                    "$ref": "#/definitions/AuditLog"
+                },
+                {
+                    "properties": {
+                        "status": {
+                            "type": "string"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Fix documentation driven validation regarding the usage of allOf's for composition.
It should not matter whether the properties in a definition are composed with allOf and refs or by declaring some properties inline - the response json would be the same