### PR TITLE
[James] upgrades assertJ to 3.8.0 and bumps build version to 0.5.2-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 }
 description = 'A Swagger assertion library'
-version = '0.5.1-SNAPSHOT'
+version = '0.5.2-SNAPSHOT'
 group = 'io.github.robwin'
 
 apply plugin: 'java'
@@ -39,7 +39,7 @@ dependencies {
     compile "io.swagger:swagger-compat-spec-parser:1.0.17"
     compile "commons-collections:commons-collections:3.2.1"
     compile "org.slf4j:slf4j-api:1.7.12"
-    compile "org.assertj:assertj-core:2.0.0"
+    compile "org.assertj:assertj-core:3.8.0"
     testCompile "junit:junit:4.11"
     testCompile "ch.qos.logback:logback-classic:1.1.2"
 


### PR DESCRIPTION
I realised you bumped travis JDK to 8 recently so this should work