### PR TITLE
Swagger parser version has been updated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ repositories {
 }
 
 dependencies {
-    compile "io.swagger:swagger-compat-spec-parser:1.0.17"
+    compile "io.swagger:swagger-compat-spec-parser:1.0.32"
     compile "commons-collections:commons-collections:3.2.1"
     compile "org.slf4j:slf4j-api:1.7.12"
     compile "org.assertj:assertj-core:3.8.0"


### PR DESCRIPTION
A newer version supports io.swagger » swagger-core 1.5.16 inside which is the latest one