### PR TITLE
Ensure consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+max_line_length = 160
+
+[*.html]
+max_line_length = off

--- a/src/main/java/io/github/robwin/swagger/loader/Swagger20Parser.java
+++ b/src/main/java/io/github/robwin/swagger/loader/Swagger20Parser.java
@@ -36,18 +36,17 @@ public class Swagger20Parser {
 
     private static Swagger convertToSwagger(String data) throws IOException {
         ObjectMapper mapper;
-        if(data.trim().startsWith("{")){
+        if (data.trim().startsWith("{")) {
             mapper = Json.mapper();
-        }
-        else {
+        } else {
             mapper = Yaml.mapper();
         }
         JsonNode rootNode = mapper.readTree(data);
         // must have swagger node set
         JsonNode swaggerNode = rootNode.get("swagger");
-        if(swaggerNode == null){
+        if (swaggerNode == null) {
             throw new IllegalArgumentException("Swagger String has an invalid format.");
-        }else{
+        } else {
             return mapper.convertValue(rootNode, Swagger.class);
         }
     }

--- a/src/main/java/io/github/robwin/swagger/test/ConsumerDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/ConsumerDrivenValidator.java
@@ -1,7 +1,22 @@
 package io.github.robwin.swagger.test;
 
-import io.swagger.models.*;
-import io.swagger.models.parameters.*;
+import io.swagger.models.ArrayModel;
+import io.swagger.models.Info;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.RefModel;
+import io.swagger.models.Response;
+import io.swagger.models.Swagger;
+import io.swagger.models.parameters.BodyParameter;
+import io.swagger.models.parameters.CookieParameter;
+import io.swagger.models.parameters.FormParameter;
+import io.swagger.models.parameters.HeaderParameter;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.models.parameters.PathParameter;
+import io.swagger.models.parameters.QueryParameter;
+import io.swagger.models.parameters.RefParameter;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
@@ -11,7 +26,13 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.SoftAssertions;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 /**
@@ -68,9 +89,9 @@ class ConsumerDrivenValidator implements ContractValidator {
     }
 
     private void validatePaths(Map<String, Path> actualPaths, Map<String, Path> expectedPaths) {
-        if(MapUtils.isNotEmpty(expectedPaths)) {
+        if (MapUtils.isNotEmpty(expectedPaths)) {
             softAssertions.assertThat(actualPaths).as("Checking Paths").isNotEmpty();
-            if(MapUtils.isNotEmpty(actualPaths)){
+            if (MapUtils.isNotEmpty(actualPaths)) {
                 softAssertions.assertThat(actualPaths.keySet()).as("Checking Paths").containsAll(expectedPaths.keySet());
                 for (Map.Entry<String, Path> actualPathEntry : actualPaths.entrySet()) {
                     Path expectedPath = expectedPaths.get(actualPathEntry.getKey());
@@ -79,15 +100,15 @@ class ConsumerDrivenValidator implements ContractValidator {
                     validatePath(pathName, actualPath, expectedPath);
                 }
             }
-        }else{
+        } else {
             softAssertions.assertThat(actualPaths).as("Checking Paths").isNullOrEmpty();
         }
     }
 
     private void validateDefinitions(Map<String, Model> actualDefinitions, Map<String, Model> expectedDefinitions) {
-        if(MapUtils.isNotEmpty(expectedDefinitions)) {
+        if (MapUtils.isNotEmpty(expectedDefinitions)) {
             softAssertions.assertThat(actualDefinitions).as("Checking Definitions").isNotEmpty();
-            if(MapUtils.isNotEmpty(actualDefinitions)){
+            if (MapUtils.isNotEmpty(actualDefinitions)) {
                 softAssertions.assertThat(actualDefinitions.keySet()).as("Checking Definitions").containsAll(expectedDefinitions.keySet());
                 for (Map.Entry<String, Model> expectedDefinitionEntry : expectedDefinitions.entrySet()) {
                     Model expectedDefinition = expectedDefinitionEntry.getValue();
@@ -119,17 +140,17 @@ class ConsumerDrivenValidator implements ContractValidator {
                                          definitionName);
 
             if (expectedDefinition instanceof ModelImpl) {
-                validateDefinitionRequiredProperties(((ModelImpl)actualDefinition).getRequired(),
-                                                     ((ModelImpl)expectedDefinition).getRequired(),
+                validateDefinitionRequiredProperties(((ModelImpl) actualDefinition).getRequired(),
+                                                     ((ModelImpl) expectedDefinition).getRequired(),
                                                        definitionName);
             }
         }
     }
 
     private void validateDefinitionRequiredProperties(List<String> actualRequiredProperties, List<String> expectedRequiredProperties, String definitionName) {
-        if(CollectionUtils.isNotEmpty(expectedRequiredProperties)) {
+        if (CollectionUtils.isNotEmpty(expectedRequiredProperties)) {
             softAssertions.assertThat(actualRequiredProperties).as("Checking required properties of definition '%s'", definitionName).isNotEmpty();
-            if(CollectionUtils.isNotEmpty(actualRequiredProperties)){
+            if (CollectionUtils.isNotEmpty(actualRequiredProperties)) {
                 final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName, new HashSet<>(expectedRequiredProperties));
                 softAssertions.assertThat(actualRequiredProperties).as("Checking required properties of definition '%s'", definitionName).hasSameElementsAs(filteredExpectedProperties);
             }
@@ -147,10 +168,10 @@ class ConsumerDrivenValidator implements ContractValidator {
                 // TODO Validate RefModel
                 softAssertions.assertThat(actualDefinition).as(message).isExactlyInstanceOf(RefModel.class);
             } else if (expectedDefinition instanceof ArrayModel) {
-                ArrayModel arrayModel = ((ArrayModel) expectedDefinition);
+                ArrayModel arrayModel = (ArrayModel) expectedDefinition;
                 // TODO Validate ArrayModel
                 softAssertions.assertThat(actualDefinition).as(message).isExactlyInstanceOf(ArrayModel.class);
-            }else{
+            } else {
                 // TODO Validate all model types
                 softAssertions.assertThat(actualDefinition).isExactlyInstanceOf(expectedDefinition.getClass());
             }
@@ -158,9 +179,9 @@ class ConsumerDrivenValidator implements ContractValidator {
     }
 
     private void validateDefinitionProperties(Map<String, Property> actualDefinitionProperties, Map<String, Property> expectedDefinitionProperties, String definitionName) {
-        if(MapUtils.isNotEmpty(expectedDefinitionProperties)) {
+        if (MapUtils.isNotEmpty(expectedDefinitionProperties)) {
             softAssertions.assertThat(actualDefinitionProperties).as("Checking properties of definition '%s", definitionName).isNotEmpty();
-            if(MapUtils.isNotEmpty(actualDefinitionProperties)){
+            if (MapUtils.isNotEmpty(actualDefinitionProperties)) {
                 final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName, expectedDefinitionProperties.keySet());
                 softAssertions.assertThat(actualDefinitionProperties.keySet()).as("Checking properties of definition '%s'", definitionName).containsAll(filteredExpectedProperties);
                 for (Map.Entry<String, Property> expectedDefinitionPropertyEntry : expectedDefinitionProperties.entrySet()) {
@@ -195,12 +216,12 @@ class ConsumerDrivenValidator implements ContractValidator {
                     StringProperty expectedStringProperty = (StringProperty) expectedProperty;
                     softAssertions.assertThat(actualProperty).as(message).isExactlyInstanceOf(StringProperty.class);
                     // TODO Validate StringProperty
-                    if(actualProperty instanceof StringProperty){
+                    if (actualProperty instanceof StringProperty) {
                         StringProperty actualStringProperty = (StringProperty) expectedProperty;
                         List<String> expectedEnums = expectedStringProperty.getEnum();
                         if (CollectionUtils.isNotEmpty(expectedEnums)) {
                             softAssertions.assertThat(actualStringProperty.getEnum()).hasSameElementsAs(expectedEnums);
-                        }else{
+                        } else {
                             softAssertions.assertThat(actualStringProperty.getEnum()).isNullOrEmpty();
                         }
                     }
@@ -213,18 +234,18 @@ class ConsumerDrivenValidator implements ContractValidator {
 
     }
 
-    private void validateOperation(Operation actualOperation, Operation expectedOperation, String path, String httpMethod){
+    private void validateOperation(Operation actualOperation, Operation expectedOperation, String path, String httpMethod) {
         String message = String.format("Checking '%s' operation of path '%s'", httpMethod, path);
-        if(expectedOperation != null){
-            if(actualOperation != null) {
+        if (expectedOperation != null) {
+            if (actualOperation != null) {
                 softAssertions.assertThat(actualOperation).as(message).isNotNull();
                 //Validate consumes
                 validateList(schemaObjectResolver.getActualConsumes(actualOperation),
-                        schemaObjectResolver.getExpectedConsumes((expectedOperation)),
+                        schemaObjectResolver.getExpectedConsumes(expectedOperation),
                         String.format("Checking '%s' of '%s' operation of path '%s'", "consumes", httpMethod, path));
                 //Validate produces
                 validateList(schemaObjectResolver.getActualProduces(actualOperation),
-                        schemaObjectResolver.getExpectedProduces((expectedOperation)),
+                        schemaObjectResolver.getExpectedProduces(expectedOperation),
                         String.format("Checking '%s' of '%s' operation of path '%s'", "produces", httpMethod, path));
                 //Validate parameters
                 validateParameters(actualOperation.getParameters(), expectedOperation.getParameters(), httpMethod, path);
@@ -264,7 +285,7 @@ class ConsumerDrivenValidator implements ContractValidator {
     }
 
     private void validateParameter(Parameter actualParameter, Parameter expectedParameter, String parameterName, String httpMethod, String path) {
-        if(expectedParameter != null) {
+        if (expectedParameter != null) {
             String message = String.format("Checking parameter '%s' of '%s' operation of path '%s'", parameterName, httpMethod, path);
             softAssertions.assertThat(actualParameter).as(message).isExactlyInstanceOf(expectedParameter.getClass());
             if (expectedParameter instanceof BodyParameter && actualParameter instanceof BodyParameter) {
@@ -331,18 +352,18 @@ class ConsumerDrivenValidator implements ContractValidator {
 
     private void validateResponses(Map<String, Response> actualOperationResponses, Map<String, Response> expectedOperationResponses, String httpMethod, String path) {
         String message = String.format("Checking responses of '%s' operation of path '%s'", httpMethod, path);
-        if(MapUtils.isNotEmpty(expectedOperationResponses)) {
+        if (MapUtils.isNotEmpty(expectedOperationResponses)) {
             softAssertions.assertThat(actualOperationResponses).as(message).isNotEmpty();
-            if(MapUtils.isNotEmpty(actualOperationResponses)) {
+            if (MapUtils.isNotEmpty(actualOperationResponses)) {
                 softAssertions.assertThat(actualOperationResponses.keySet()).as(message).hasSameElementsAs(expectedOperationResponses.keySet());
                 for (Map.Entry<String, Response> actualResponseEntry : actualOperationResponses.entrySet()) {
                     Response expectedResponse = expectedOperationResponses.get(actualResponseEntry.getKey());
                     Response actualResponse = actualResponseEntry.getValue();
                     String responseName = actualResponseEntry.getKey();
-                    validateResponse( actualResponse, expectedResponse, responseName, httpMethod, path);
+                    validateResponse(actualResponse, expectedResponse, responseName, httpMethod, path);
                 }
             }
-        }else{
+        } else {
             softAssertions.assertThat(actualOperationResponses).as(message).isNullOrEmpty();
         }
     }
@@ -356,9 +377,9 @@ class ConsumerDrivenValidator implements ContractValidator {
 
     private void validateResponseHeaders(Map<String, Property> actualResponseHeaders, Map<String, Property> expectedResponseHeaders, String responseName, String httpMethod, String path) {
         String message = String.format("Checking response headers of response '%s' of '%s' operation of path '%s'", responseName, httpMethod, path);
-        if(MapUtils.isNotEmpty(expectedResponseHeaders)) {
+        if (MapUtils.isNotEmpty(expectedResponseHeaders)) {
             softAssertions.assertThat(actualResponseHeaders).as(message).isNotEmpty();
-            if(MapUtils.isNotEmpty(actualResponseHeaders)){
+            if (MapUtils.isNotEmpty(actualResponseHeaders)) {
                 softAssertions.assertThat(actualResponseHeaders.keySet()).as(message).containsAll(expectedResponseHeaders.keySet());
                 for (Map.Entry<String, Property> expectedResponseHeaderEntry : expectedResponseHeaders.entrySet()) {
                     Property expectedResponseHeader = expectedResponseHeaderEntry.getValue();
@@ -367,18 +388,18 @@ class ConsumerDrivenValidator implements ContractValidator {
                     validateProperty(actualResponseHeader, expectedResponseHeader, String.format("Checking response header '%s' of response '%s' of '%s' operation of path '%s'", responseHeaderName, responseName, httpMethod, path));
                 }
             }
-        }else{
+        } else {
             softAssertions.assertThat(actualResponseHeaders).as(message).isNullOrEmpty();
         }
     }
 
-    private void validateList(List<String> actualList, List<String> expectedList, String message){
-        if(CollectionUtils.isNotEmpty(expectedList)) {
+    private void validateList(List<String> actualList, List<String> expectedList, String message) {
+        if (CollectionUtils.isNotEmpty(expectedList)) {
             softAssertions.assertThat(actualList).as(message).isNotEmpty();
-            if(CollectionUtils.isNotEmpty(actualList)) {
+            if (CollectionUtils.isNotEmpty(actualList)) {
                 softAssertions.assertThat(actualList).as(message).containsAll(expectedList);
             }
-        }else{
+        } else {
             softAssertions.assertThat(actualList).as(message).isNullOrEmpty();
         }
     }

--- a/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
@@ -1,7 +1,23 @@
 package io.github.robwin.swagger.test;
 
-import io.swagger.models.*;
-import io.swagger.models.parameters.*;
+import io.swagger.models.ArrayModel;
+import io.swagger.models.ComposedModel;
+import io.swagger.models.Info;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.RefModel;
+import io.swagger.models.Response;
+import io.swagger.models.Swagger;
+import io.swagger.models.parameters.BodyParameter;
+import io.swagger.models.parameters.CookieParameter;
+import io.swagger.models.parameters.FormParameter;
+import io.swagger.models.parameters.HeaderParameter;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.models.parameters.PathParameter;
+import io.swagger.models.parameters.QueryParameter;
+import io.swagger.models.parameters.RefParameter;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
@@ -11,7 +27,12 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.SoftAssertions;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 class DocumentationDrivenValidator implements ContractValidator {
 
@@ -28,7 +49,7 @@ class DocumentationDrivenValidator implements ContractValidator {
     }
 
     @Override
-	public void validateSwagger(Swagger expected, SchemaObjectResolver schemaObjectResolver) {
+    public void validateSwagger(Swagger expected, SchemaObjectResolver schemaObjectResolver) {
         this.schemaObjectResolver = schemaObjectResolver;
 
         validateInfo(actual.getInfo(), expected.getInfo());
@@ -63,9 +84,9 @@ class DocumentationDrivenValidator implements ContractValidator {
     }
 
     private void validatePaths(Map<String, Path> actualPaths, Map<String, Path> expectedPaths) {
-        if(MapUtils.isNotEmpty(expectedPaths)) {
+        if (MapUtils.isNotEmpty(expectedPaths)) {
             softAssertions.assertThat(actualPaths).as("Checking Paths").isNotEmpty();
-            if(MapUtils.isNotEmpty(actualPaths)){
+            if (MapUtils.isNotEmpty(actualPaths)) {
                 softAssertions.assertThat(actualPaths.keySet()).as("Checking Paths").hasSameElementsAs(expectedPaths.keySet());
                 for (Map.Entry<String, Path> actualPathEntry : actualPaths.entrySet()) {
                     Path expectedPath = expectedPaths.get(actualPathEntry.getKey());
@@ -74,15 +95,15 @@ class DocumentationDrivenValidator implements ContractValidator {
                     validatePath(pathName, actualPath, expectedPath);
                 }
             }
-        }else{
+        } else {
             softAssertions.assertThat(actualPaths).as("Checking Paths").isNullOrEmpty();
         }
     }
 
     private void validateDefinitions(Map<String, Model> actualDefinitions, Map<String, Model> expectedDefinitions) {
-        if(MapUtils.isNotEmpty(expectedDefinitions)) {
+        if (MapUtils.isNotEmpty(expectedDefinitions)) {
             softAssertions.assertThat(actualDefinitions).as("Checking Definitions").isNotEmpty();
-            if(MapUtils.isNotEmpty(actualDefinitions)){
+            if (MapUtils.isNotEmpty(actualDefinitions)) {
                 softAssertions.assertThat(actualDefinitions.keySet()).as("Checking Definitions").hasSameElementsAs(expectedDefinitions.keySet());
                 for (Map.Entry<String, Model> actualDefinitionEntry : actualDefinitions.entrySet()) {
                     Model expectedDefinition = expectedDefinitions.get(actualDefinitionEntry.getKey());
@@ -91,7 +112,7 @@ class DocumentationDrivenValidator implements ContractValidator {
                     validateDefinition(definitionName, actualDefinition, expectedDefinition);
                 }
             }
-        }else{
+        } else {
             softAssertions.assertThat(actualDefinitions).as("Checking Definitions").isNullOrEmpty();
         }
     }
@@ -116,17 +137,17 @@ class DocumentationDrivenValidator implements ContractValidator {
                                          definitionName);
 
             if (expectedDefinition instanceof ModelImpl) {
-                validateDefinitionRequiredProperties(((ModelImpl)actualDefinition).getRequired(),
-                                                     ((ModelImpl)expectedDefinition).getRequired(),
+                validateDefinitionRequiredProperties(((ModelImpl) actualDefinition).getRequired(),
+                                                     ((ModelImpl) expectedDefinition).getRequired(),
                                                        definitionName);
             }
         }
     }
 
     private void validateDefinitionRequiredProperties(List<String> actualRequiredProperties, List<String> expectedRequiredProperties, String definitionName) {
-        if(CollectionUtils.isNotEmpty(expectedRequiredProperties)) {
+        if (CollectionUtils.isNotEmpty(expectedRequiredProperties)) {
             softAssertions.assertThat(actualRequiredProperties).as("Checking required properties of definition '%s'", definitionName).isNotEmpty();
-            if(CollectionUtils.isNotEmpty(actualRequiredProperties)){
+            if (CollectionUtils.isNotEmpty(actualRequiredProperties)) {
                 final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName, new HashSet<>(expectedRequiredProperties));
                 softAssertions.assertThat(actualRequiredProperties).as("Checking required properties of definition '%s'", definitionName).hasSameElementsAs(filteredExpectedProperties);
             }
@@ -144,13 +165,13 @@ class DocumentationDrivenValidator implements ContractValidator {
                 // TODO Validate RefModel
                 softAssertions.assertThat(actualDefinition).as(message).isExactlyInstanceOf(RefModel.class);
             } else if (expectedDefinition instanceof ArrayModel) {
-                ArrayModel arrayModel = ((ArrayModel) expectedDefinition);
+                ArrayModel arrayModel = (ArrayModel) expectedDefinition;
                 // TODO Validate ArrayModel
                 softAssertions.assertThat(actualDefinition).as(message).isExactlyInstanceOf(ArrayModel.class);
             } else if (expectedDefinition instanceof ComposedModel) {
                 ComposedModel composedModel = (ComposedModel) expectedDefinition;
                 softAssertions.assertThat(actualDefinition).as(message).isInstanceOfAny(ComposedModel.class, ModelImpl.class);
-            } else{
+            } else {
                 // TODO Validate all model types
                 softAssertions.assertThat(actualDefinition).isExactlyInstanceOf(expectedDefinition.getClass());
             }
@@ -158,9 +179,9 @@ class DocumentationDrivenValidator implements ContractValidator {
     }
 
     private void validateDefinitionProperties(Map<String, Property> actualDefinitionProperties, Map<String, Property> expectedDefinitionProperties, String definitionName) {
-        if(MapUtils.isNotEmpty(expectedDefinitionProperties)) {
+        if (MapUtils.isNotEmpty(expectedDefinitionProperties)) {
             softAssertions.assertThat(actualDefinitionProperties).as("Checking properties of definition '%s", definitionName).isNotEmpty();
-            if(MapUtils.isNotEmpty(actualDefinitionProperties)){
+            if (MapUtils.isNotEmpty(actualDefinitionProperties)) {
                 final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName, expectedDefinitionProperties.keySet());
                 softAssertions.assertThat(actualDefinitionProperties.keySet()).as("Checking properties of definition '%s'", definitionName).hasSameElementsAs(filteredExpectedProperties);
                 for (Map.Entry<String, Property> actualDefinitionPropertyEntry : actualDefinitionProperties.entrySet()) {
@@ -195,12 +216,12 @@ class DocumentationDrivenValidator implements ContractValidator {
                     StringProperty expectedStringProperty = (StringProperty) expectedProperty;
                     softAssertions.assertThat(actualProperty).as(message).isExactlyInstanceOf(StringProperty.class);
                     // TODO Validate StringProperty
-                    if(actualProperty instanceof StringProperty){
+                    if (actualProperty instanceof StringProperty) {
                         StringProperty actualStringProperty = (StringProperty) expectedProperty;
                         List<String> expectedEnums = expectedStringProperty.getEnum();
                         if (CollectionUtils.isNotEmpty(expectedEnums)) {
                             softAssertions.assertThat(actualStringProperty.getEnum()).hasSameElementsAs(expectedEnums);
-                        }else{
+                        } else {
                             softAssertions.assertThat(actualStringProperty.getEnum()).isNullOrEmpty();
                         }
                     }
@@ -213,53 +234,53 @@ class DocumentationDrivenValidator implements ContractValidator {
 
     }
 
-    private void validateOperation(Operation actualOperation, Operation expectedOperation, String path, String httpMethod){
+    private void validateOperation(Operation actualOperation, Operation expectedOperation, String path, String httpMethod) {
         String message = String.format("Checking '%s' operation of path '%s'", httpMethod, path);
-        if(expectedOperation != null){
+        if (expectedOperation != null) {
             softAssertions.assertThat(actualOperation).as(message).isNotNull();
-            if(actualOperation != null) {
+            if (actualOperation != null) {
                 //Validate consumes
                 validateList(schemaObjectResolver.getActualConsumes(actualOperation),
-                        schemaObjectResolver.getExpectedConsumes((expectedOperation)),
+                        schemaObjectResolver.getExpectedConsumes(expectedOperation),
                         String.format("Checking '%s' of '%s' operation of path '%s'", "consumes", httpMethod, path));
                 //Validate produces
                 validateList(schemaObjectResolver.getActualProduces(actualOperation),
-                        schemaObjectResolver.getExpectedProduces((expectedOperation)),
+                        schemaObjectResolver.getExpectedProduces(expectedOperation),
                         String.format("Checking '%s' of '%s' operation of path '%s'", "produces", httpMethod, path));
                 //Validate parameters
                 validateParameters(actualOperation.getParameters(), expectedOperation.getParameters(), httpMethod, path);
                 //Validate responses
                 validateResponses(actualOperation.getResponses(), expectedOperation.getResponses(), httpMethod, path);
             }
-        }else{
+        } else {
             softAssertions.assertThat(actualOperation).as(message).isNull();
         }
     }
 
     private void validateParameters(List<Parameter> actualOperationParameters,  List<Parameter> expectedOperationParameters, String httpMethod, String path) {
         String message = String.format("Checking parameters of '%s' operation of path '%s'", httpMethod, path);
-        if(CollectionUtils.isNotEmpty(expectedOperationParameters)) {
+        if (CollectionUtils.isNotEmpty(expectedOperationParameters)) {
             softAssertions.assertThat(actualOperationParameters).as(message).isNotEmpty();
-            if(CollectionUtils.isNotEmpty(actualOperationParameters)) {
+            if (CollectionUtils.isNotEmpty(actualOperationParameters)) {
                 softAssertions.assertThat(actualOperationParameters).as(message).hasSameSizeAs(expectedOperationParameters);
                 softAssertions.assertThat(actualOperationParameters).as(message).usingElementComparatorOnFields("in", "name", "required").hasSameElementsAs(expectedOperationParameters);
-                Map<String,Parameter> expectedParametersAsMap = new HashMap<>();
-                for(Parameter expectedParameter : expectedOperationParameters){
+                Map<String, Parameter> expectedParametersAsMap = new HashMap<>();
+                for (Parameter expectedParameter : expectedOperationParameters) {
                     expectedParametersAsMap.put(expectedParameter.getName(), expectedParameter);
                 }
-                for(Parameter actualParameter : actualOperationParameters){
+                for (Parameter actualParameter : actualOperationParameters) {
                     String parameterName = actualParameter.getName();
                     Parameter expectedParameter = expectedParametersAsMap.get(parameterName);
                     validateParameter(actualParameter, expectedParameter, parameterName, httpMethod, path);
                 }
             }
-        }else{
+        } else {
             softAssertions.assertThat(actualOperationParameters).as(message).isNullOrEmpty();
         }
     }
 
     private void validateParameter(Parameter actualParameter, Parameter expectedParameter, String parameterName, String httpMethod, String path) {
-        if(expectedParameter != null) {
+        if (expectedParameter != null) {
             String message = String.format("Checking parameter '%s' of '%s' operation of path '%s'", parameterName, httpMethod, path);
             softAssertions.assertThat(actualParameter).as(message).isExactlyInstanceOf(expectedParameter.getClass());
             if (expectedParameter instanceof BodyParameter && actualParameter instanceof BodyParameter) {
@@ -326,18 +347,18 @@ class DocumentationDrivenValidator implements ContractValidator {
 
     private void validateResponses(Map<String, Response> actualOperationResponses, Map<String, Response> expectedOperationResponses, String httpMethod, String path) {
         String message = String.format("Checking responses of '%s' operation of path '%s'", httpMethod, path);
-        if(MapUtils.isNotEmpty(expectedOperationResponses)) {
+        if (MapUtils.isNotEmpty(expectedOperationResponses)) {
             softAssertions.assertThat(actualOperationResponses).as(message).isNotEmpty();
-            if(MapUtils.isNotEmpty(actualOperationResponses)) {
+            if (MapUtils.isNotEmpty(actualOperationResponses)) {
                 softAssertions.assertThat(actualOperationResponses.keySet()).as(message).hasSameElementsAs(expectedOperationResponses.keySet());
                 for (Map.Entry<String, Response> actualResponseEntry : actualOperationResponses.entrySet()) {
                     Response expectedResponse = expectedOperationResponses.get(actualResponseEntry.getKey());
                     Response actualResponse = actualResponseEntry.getValue();
                     String responseName = actualResponseEntry.getKey();
-                    validateResponse( actualResponse, expectedResponse, responseName, httpMethod, path);
+                    validateResponse(actualResponse, expectedResponse, responseName, httpMethod, path);
                 }
             }
-        }else{
+        } else {
             softAssertions.assertThat(actualOperationResponses).as(message).isNullOrEmpty();
         }
     }
@@ -351,9 +372,9 @@ class DocumentationDrivenValidator implements ContractValidator {
 
     private void validateResponseHeaders(Map<String, Property> actualResponseHeaders, Map<String, Property> expectedResponseHeaders, String responseName, String httpMethod, String path) {
         String message = String.format("Checking response headers of response '%s' of '%s' operation of path '%s'", responseName, httpMethod, path);
-        if(MapUtils.isNotEmpty(expectedResponseHeaders)) {
+        if (MapUtils.isNotEmpty(expectedResponseHeaders)) {
             softAssertions.assertThat(actualResponseHeaders).as(message).isNotEmpty();
-            if(MapUtils.isNotEmpty(actualResponseHeaders)){
+            if (MapUtils.isNotEmpty(actualResponseHeaders)) {
                 softAssertions.assertThat(actualResponseHeaders.keySet()).as(message).hasSameElementsAs(expectedResponseHeaders.keySet());
                 for (Map.Entry<String, Property> actualResponseHeaderEntry : actualResponseHeaders.entrySet()) {
                     Property expectedResponseHeader = expectedResponseHeaders.get(actualResponseHeaderEntry.getKey());
@@ -362,18 +383,18 @@ class DocumentationDrivenValidator implements ContractValidator {
                     validateProperty(actualResponseHeader, expectedResponseHeader, String.format("Checking response header '%s' of response '%s' of '%s' operation of path '%s'", responseHeaderName, responseName, httpMethod, path));
                 }
             }
-        }else{
+        } else {
             softAssertions.assertThat(actualResponseHeaders).as(message).isNullOrEmpty();
         }
     }
 
-    private void validateList(List<String> actualList, List<String> expectedList, String message){
-        if(CollectionUtils.isNotEmpty(expectedList)) {
+    private void validateList(List<String> actualList, List<String> expectedList, String message) {
+        if (CollectionUtils.isNotEmpty(expectedList)) {
             softAssertions.assertThat(actualList).as(message).isNotEmpty();
-            if(CollectionUtils.isNotEmpty(actualList)) {
+            if (CollectionUtils.isNotEmpty(actualList)) {
                 softAssertions.assertThat(actualList).as(message).hasSameElementsAs(expectedList);
             }
-        }else{
+        } else {
             softAssertions.assertThat(actualList).as(message).isNullOrEmpty();
         }
     }

--- a/src/main/java/io/github/robwin/swagger/test/SchemaObjectResolver.java
+++ b/src/main/java/io/github/robwin/swagger/test/SchemaObjectResolver.java
@@ -1,9 +1,18 @@
 package io.github.robwin.swagger.test;
 
-import io.swagger.models.*;
+import io.swagger.models.ComposedModel;
+import io.swagger.models.Model;
+import io.swagger.models.Operation;
+import io.swagger.models.RefModel;
+import io.swagger.models.Swagger;
 import io.swagger.models.properties.Property;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -65,7 +74,7 @@ class SchemaObjectResolver {
             if (definitionProperties != null) {
                 allProperties.putAll(definitionProperties);
             }
-            for (final Model childDefinition : ((ComposedModel)definition).getAllOf()) {
+            for (final Model childDefinition : ((ComposedModel) definition).getAllOf()) {
                 allProperties.putAll(resolveProperties(childDefinition, owningSchema, seenRefs));
             }
             result = allProperties;

--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
@@ -111,9 +111,10 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
 
     private SwaggerAssertionConfig loadSwaggerAssertionFlagsConfiguration(String configurationResourceLocation) {
         final Properties props = new Properties();
-        try (final InputStream is = this.getClass().getResourceAsStream(configurationResourceLocation)) {
-            if (is != null)
+        try (InputStream is = this.getClass().getResourceAsStream(configurationResourceLocation)) {
+            if (is != null) {
                 props.load(is);
+            }
         } catch (final IOException ioe) {
             // eat it.
         }

--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionConfig.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionConfig.java
@@ -2,7 +2,13 @@ package io.github.robwin.swagger.test;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 
 public class SwaggerAssertionConfig {
 
@@ -70,7 +76,7 @@ public class SwaggerAssertionConfig {
 
     public boolean swaggerAssertionEnabled(SwaggerAssertionType assertionType) {
         final Boolean flag = swaggerAssertionFlags.get(assertionType);
-        return (flag != null ? flag : assertionType.isEnabledByDefault());
+        return flag != null ? flag : assertionType.isEnabledByDefault();
     }
 
     public Set<String> getPathsToIgnoreInExpected() {
@@ -81,7 +87,9 @@ public class SwaggerAssertionConfig {
         return definitionsToIgnoreInExpected;
     }
 
-    public Set<String> getPropertiesToIgnoreInExpected() { return propertiesToIgnoreInExpected; }
+    public Set<String> getPropertiesToIgnoreInExpected() {
+        return propertiesToIgnoreInExpected;
+    }
 
     public String getPathsPrependExpected() {
         return pathsPrependExpected;

--- a/src/test/java/io/github/robwin/swagger/SwaggerConsumerDrivenAssertTest.java
+++ b/src/test/java/io/github/robwin/swagger/SwaggerConsumerDrivenAssertTest.java
@@ -18,13 +18,13 @@
  */
 package io.github.robwin.swagger;
 
-import java.io.File;
-
 import io.github.robwin.swagger.test.SwaggerAssert;
 import io.github.robwin.swagger.test.SwaggerAssertions;
 import io.swagger.parser.SwaggerParser;
 import org.apache.commons.lang3.Validate;
 import org.junit.Test;
+
+import java.io.File;
 
 public class SwaggerConsumerDrivenAssertTest {
 
@@ -157,7 +157,7 @@ public class SwaggerConsumerDrivenAssertTest {
     }
 
     @Test
-    public void shouldPassTestForIdenticalParametersSetContainsParameterWithDifferentTypes(){
+    public void shouldPassTestForIdenticalParametersSetContainsParameterWithDifferentTypes() {
         File swaggerFile = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-with-multi-types-parameters.json").getPath());
         SwaggerAssertions.assertThat(swaggerFile.getAbsolutePath()).satisfiesContract(swaggerFile.getAbsolutePath());
 

--- a/src/test/java/io/github/robwin/swagger/SwaggerDocumentationDrivenAssertTest.java
+++ b/src/test/java/io/github/robwin/swagger/SwaggerDocumentationDrivenAssertTest.java
@@ -29,35 +29,35 @@ import java.io.File;
 public class SwaggerDocumentationDrivenAssertTest {
 
     @Test
-    public void shouldFindNoDifferences(){
+    public void shouldFindNoDifferences() {
         File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.json").getFile());
         File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getFile());
         SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
-    public void shouldFindDifferencesInImplementation(){
+    public void shouldFindDifferencesInImplementation() {
         File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/wrong_swagger.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
         SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
-    public void shouldFindDifferencesInParameterNaming(){
+    public void shouldFindDifferencesInParameterNaming() {
         File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger-name-changes.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
         SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
-    public void shouldFindDifferencesInRequiredness(){
+    public void shouldFindDifferencesInRequiredness() {
         File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger-requiredness-changes.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
         SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
-    public void shouldFindDifferencesInInfo(){
+    public void shouldFindDifferencesInInfo() {
         // Otherwise-good comparison will fail here, because 'info.title' is different
         File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
@@ -65,8 +65,8 @@ public class SwaggerDocumentationDrivenAssertTest {
                 .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
-    @Test()
-    public void shouldHandlePartiallyImplementedApi(){
+    @Test
+    public void shouldHandlePartiallyImplementedApi() {
         File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/partial_impl_swagger.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
 
@@ -75,8 +75,8 @@ public class SwaggerDocumentationDrivenAssertTest {
                 .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
-    @Test()
-    public void shouldHandleExpectedPathsWithPrefix(){
+    @Test
+    public void shouldHandleExpectedPathsWithPrefix() {
         File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger_with_path_prefixes.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
 
@@ -104,12 +104,12 @@ public class SwaggerDocumentationDrivenAssertTest {
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-allOf.properties")
                 .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
-    
+
     @Test
     public void shouldHandleDefinitionsUsingAllOfForComposition() {
         File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-composition-flat.json").getPath());
         File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-composition.json").getPath());
-        
+
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
                 .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
@@ -124,5 +124,5 @@ public class SwaggerDocumentationDrivenAssertTest {
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
                 .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
-    
+
 }

--- a/src/test/resources/partial_impl_swagger.json
+++ b/src/test/resources/partial_impl_swagger.json
@@ -479,7 +479,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger-added-optional-parameter.json
+++ b/src/test/resources/swagger-added-optional-parameter.json
@@ -777,7 +777,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger-added-required-parameter.json
+++ b/src/test/resources/swagger-added-required-parameter.json
@@ -777,7 +777,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger-extraresource.json
+++ b/src/test/resources/swagger-extraresource.json
@@ -421,7 +421,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"
@@ -461,7 +461,7 @@
             }
         },
         "Animal": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name"
             ],

--- a/src/test/resources/swagger-missing-required-field-object.json
+++ b/src/test/resources/swagger-missing-required-field-object.json
@@ -770,7 +770,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name"
             ],

--- a/src/test/resources/swagger-name-changes.json
+++ b/src/test/resources/swagger-name-changes.json
@@ -770,7 +770,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger-path-without-some-operations.json
+++ b/src/test/resources/swagger-path-without-some-operations.json
@@ -129,7 +129,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger-pets-by-petId-without-get-and-post.json
+++ b/src/test/resources/swagger-pets-by-petId-without-get-and-post.json
@@ -672,7 +672,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger-requiredness-changes.json
+++ b/src/test/resources/swagger-requiredness-changes.json
@@ -770,7 +770,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger-singleresource-extramethod.json
+++ b/src/test/resources/swagger-singleresource-extramethod.json
@@ -371,7 +371,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger-singleresource-extraproperty.json
+++ b/src/test/resources/swagger-singleresource-extraproperty.json
@@ -323,7 +323,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger-singleresource-partialmodel.json
+++ b/src/test/resources/swagger-singleresource-partialmodel.json
@@ -323,7 +323,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger-singleresource.json
+++ b/src/test/resources/swagger-singleresource.json
@@ -323,7 +323,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger-with-multi-types-parameters.json
+++ b/src/test/resources/swagger-with-multi-types-parameters.json
@@ -59,7 +59,6 @@
                         "type": "integer",
                         "format": "int64"
                     }
-
                 ],
                 "responses": {
                     "405": {
@@ -739,7 +738,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger.json
+++ b/src/test/resources/swagger.json
@@ -770,7 +770,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/swagger_with_path_prefixes.json
+++ b/src/test/resources/swagger_with_path_prefixes.json
@@ -769,7 +769,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"

--- a/src/test/resources/wrong_swagger.json
+++ b/src/test/resources/wrong_swagger.json
@@ -843,7 +843,7 @@
             }
         },
         "Pet": {
-            "description" : "Test description",
+            "description": "Test description",
             "required": [
                 "name",
                 "photoUrls"


### PR DESCRIPTION
I found different formatting with regards to:
- indentation (tab vs space)
- import (wildcard vs explicit)
- withspace
- EOF newline

Adding .editorconfig helps ensuring consistency. Since I'll create more material PRs later I wanted to get this out of the way first.