### PR TITLE
Add new isEqualTo with auth for secured endpoints.

### DIFF
--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
@@ -19,11 +19,13 @@
 package io.github.robwin.swagger.test;
 
 import io.swagger.models.Swagger;
+import io.swagger.models.auth.AuthorizationValue;
 import io.swagger.parser.SwaggerParser;
 import org.assertj.core.api.AbstractAssert;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Properties;
 
 
@@ -83,6 +85,18 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
      */
     public SwaggerAssert isEqualTo(String expectedLocation) {
         return isEqualTo(new SwaggerParser().read(expectedLocation));
+    }
+
+    /**
+     * Verifies that the actual value is equal to the given one.
+     * @param expectedLocation the location of the given value to compare the actual value to.
+     * @param auths List of io.swagger.models.auth.AuthorizationValue for access to the expectedLocation
+     * @return {@code this} assertion object.
+     * @throws AssertionError if the actual value is not equal to the given one or if the actual value is {@code null}..
+     */
+    public SwaggerAssert isEqualTo(String expectedLocation, List<AuthorizationValue> auths) {
+
+        return isEqualTo(new SwaggerParser().read(expectedLocation, auths, true));
     }
 
     /**

--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssert.java
@@ -89,13 +89,13 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
 
     /**
      * Verifies that the actual value is equal to the given one.
+     *
      * @param expectedLocation the location of the given value to compare the actual value to.
-     * @param auths List of io.swagger.models.auth.AuthorizationValue for access to the expectedLocation
+     * @param auths List of io.swagger.models.auth.AuthorizationValue for access to protected locations.
      * @return {@code this} assertion object.
      * @throws AssertionError if the actual value is not equal to the given one or if the actual value is {@code null}..
      */
     public SwaggerAssert isEqualTo(String expectedLocation, List<AuthorizationValue> auths) {
-
         return isEqualTo(new SwaggerParser().read(expectedLocation, auths, true));
     }
 
@@ -121,6 +121,18 @@ public class SwaggerAssert extends AbstractAssert<SwaggerAssert, Swagger> {
      */
     public SwaggerAssert satisfiesContract(String expectedLocation) {
         return satisfiesContract(new SwaggerParser().read(expectedLocation));
+    }
+
+    /**
+     * Verifies that the actual value is equal to the given one.
+     *
+     * @param expectedLocation the location of the given value to compare the actual value to.
+     * @param auths List of io.swagger.models.auth.AuthorizationValue for access to protected locations.
+     * @return {@code this} assertion object.
+     * @throws AssertionError if the actual value is not equal to the given one or if the actual value is {@code null}..
+     */
+    public SwaggerAssert satisfiesContract(String expectedLocation, List<AuthorizationValue> auths) {
+        return satisfiesContract(new SwaggerParser().read(expectedLocation, auths, true));
     }
 
     private SwaggerAssertionConfig loadSwaggerAssertionFlagsConfiguration(String configurationResourceLocation) {


### PR DESCRIPTION
Added a new isEqualTo method which supports authorization for accessing Swagger definitions stored at non-public URLs, e.g. private APIs on SwaggerHub.
It may be better not to require io.swagger.models.auth.AuthorizationValue as input to the assertj-swagger API, see what you think anyway.