### PR TITLE
Add missing validation message for property types

### DIFF
--- a/src/main/java/io/github/robwin/swagger/test/ConsumerDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/ConsumerDrivenValidator.java
@@ -228,7 +228,7 @@ class ConsumerDrivenValidator implements ContractValidator {
                 }
             } else {
                 // TODO Validate all other properties
-                softAssertions.assertThat(actualProperty).isExactlyInstanceOf(expectedProperty.getClass());
+                softAssertions.assertThat(actualProperty).as(message).isExactlyInstanceOf(expectedProperty.getClass());
             }
         }
 

--- a/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
@@ -228,7 +228,7 @@ class DocumentationDrivenValidator implements ContractValidator {
                 }
             } else {
                 // TODO Validate all other properties
-                softAssertions.assertThat(actualProperty).isExactlyInstanceOf(expectedProperty.getClass());
+                softAssertions.assertThat(actualProperty).as(message).isExactlyInstanceOf(expectedProperty.getClass());
             }
         }
 


### PR DESCRIPTION
This fixes the following - rather useless - validation output:

```
2) 
Expecting:
 <io.swagger.models.properties.IntegerProperty@d7e9e510>
to be exactly an instance of:
 <io.swagger.models.properties.BaseIntegerProperty>
but was an instance of:
 <io.swagger.models.properties.IntegerProperty>
```

The fix will add the missing context message:

```
2) [Checking property '<actual-property-name>' of definition '<definition-name>'] 
Expecting:
 <io.swagger.models.properties.IntegerProperty@d7e9e510>
to be exactly an instance of:
 <io.swagger.models.properties.BaseIntegerProperty>
but was an instance of:
 <io.swagger.models.properties.IntegerProperty>
```