### PR TITLE
Update to assertJ v3.9.1 for binary compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     compile "io.swagger:swagger-compat-spec-parser:1.0.34"
     compile "commons-collections:commons-collections:3.2.1"
     compile "org.slf4j:slf4j-api:1.7.12"
-    compile "org.assertj:assertj-core:3.9.0"
+    compile "org.assertj:assertj-core:3.9.1"
     testCompile "junit:junit:4.11"
     testCompile "ch.qos.logback:logback-classic:1.1.2"
 


### PR DESCRIPTION
Fix a java.lang.NoSuchMethodError: org.assertj.core.api.SoftAssertions.assertThat when used with assertJ3.9.1 