### PR TITLE
Enhanced definition validation

### DIFF
--- a/src/main/java/io/github/robwin/swagger/test/ConsumerDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/ConsumerDrivenValidator.java
@@ -155,7 +155,7 @@ class ConsumerDrivenValidator extends AbstractContractValidator {
                                          schemaObjectResolver.resolvePropertiesFromExpected(expectedDefinition),
                                          definitionName);
 
-            if (expectedDefinition instanceof ModelImpl) {
+            if (expectedDefinition instanceof ModelImpl && actualDefinition instanceof ModelImpl) {
                 validateDefinitionRequiredProperties(((ModelImpl) actualDefinition).getRequired(),
                                                      ((ModelImpl) expectedDefinition).getRequired(),
                                                        definitionName);

--- a/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
@@ -154,7 +154,7 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
                                          schemaObjectResolver.resolvePropertiesFromExpected(expectedDefinition),
                                          definitionName);
 
-            if (expectedDefinition instanceof ModelImpl) {
+            if (expectedDefinition instanceof ModelImpl && actualDefinition instanceof ModelImpl) {
                 validateDefinitionRequiredProperties(((ModelImpl) actualDefinition).getRequired(),
                                                      ((ModelImpl) expectedDefinition).getRequired(),
                                                        definitionName);


### PR DESCRIPTION
Enhanced definition validation checking the instance of the actual definition before validating required properties (as might throw a class cast exception if the actual definition is not of type ModelImpl)