### PR TITLE
Schema resolver avoid nullpointerexception

### DIFF
--- a/src/main/java/io/github/robwin/swagger/test/SchemaObjectResolver.java
+++ b/src/main/java/io/github/robwin/swagger/test/SchemaObjectResolver.java
@@ -75,7 +75,8 @@ class SchemaObjectResolver {
     private Map<String, Property> resolveProperties(Model definition, Swagger owningSchema, Set<String> seenRefs) {
         Map<String, Property> result;
 
-        final Map<String, Property> definitionProperties = definition.getProperties();
+        // if the definition does not contain any property, then the model will return null instead of an empty map
+        final Map<String, Property> definitionProperties = definition.getProperties() != null ? definition.getProperties() : Collections.emptyMap();
 
         if (definition instanceof RefModel) {
             // Don't navigate ref-def cycles infinitely

--- a/src/test/resources/assertj-swagger-allOf.properties
+++ b/src/test/resources/assertj-swagger-allOf.properties
@@ -1,2 +1,2 @@
 assertj.swagger.validateModels=false
-assertj.swagger.definitionsToIgnoreInExpected=AbstractOrder,Order1,Order2
+assertj.swagger.definitionsToIgnoreInExpected=AbstractOrder,Order1,Order2,OrderBase

--- a/src/test/resources/swagger-allOf-test-inheritance.json
+++ b/src/test/resources/swagger-allOf-test-inheritance.json
@@ -18,7 +18,7 @@
                 "id"
             ]
         },
-        "Order": {
+        "OrderBase": {
             "type": "object",
             "allOf": [
                 {
@@ -46,6 +46,16 @@
                             "type": "boolean"
                         }
                     }
+                }
+            ]
+        },
+        "Order": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/OrderBase"
+                },
+                {
+                    "type": "object"
                 }
             ]
         }


### PR DESCRIPTION
When in the inheritance tree there is a definition without properties but extending another specifying the type "object", a null pointer exception is thrown due to the fact that the swagger model returns null when getting the properties (instead of an empty map)