### PR TITLE
add validation for enums which are referenced to definitions section

### DIFF
--- a/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
@@ -155,10 +155,23 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
                                          definitionName);
 
             if (expectedDefinition instanceof ModelImpl && actualDefinition instanceof ModelImpl) {
+                validateDefinitionEnum(actualDefinition, expectedDefinition);
                 validateDefinitionRequiredProperties(((ModelImpl) actualDefinition).getRequired(),
                                                      ((ModelImpl) expectedDefinition).getRequired(),
                                                        definitionName);
             }
+        }
+    }
+
+    private void validateDefinitionEnum(Model actualDefinition, Model expectedDefinition) {
+        ModelImpl expectedDefModelImpl = (ModelImpl)expectedDefinition;
+        ModelImpl actualDefModelImpl = (ModelImpl)actualDefinition;
+        List<String> actualEnums = actualDefModelImpl.getEnum();
+        List<String> expectedEnums = expectedDefModelImpl.getEnum();
+        if (CollectionUtils.isNotEmpty(expectedEnums)) {
+            softAssertions.assertThat(actualEnums).hasSameElementsAs(expectedEnums);
+        } else {
+            softAssertions.assertThat(actualEnums).isNullOrEmpty();
         }
     }
 

--- a/src/test/java/io/github/robwin/swagger/SwaggerDocumentationDrivenAssertTest.java
+++ b/src/test/java/io/github/robwin/swagger/SwaggerDocumentationDrivenAssertTest.java
@@ -158,6 +158,7 @@ public class SwaggerDocumentationDrivenAssertTest {
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
                 .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
+
     @Test
     public void shouldAllowConfigurationToLooselyMatchResponse() throws IOException {
         File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.json").getPath());
@@ -182,5 +183,25 @@ public class SwaggerDocumentationDrivenAssertTest {
 
     private String toConfiguration() {
         return "assertj.swagger.validateResponseWithStrictlyMatch=false";
+    }
+        
+    @Test
+    public void shouldHandleRefEnumValues() {
+        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref.json").getPath());
+        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref.yaml").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
+                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void shouldFindDifferentRefEnumValues() {
+        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref-wrong.json").getPath());
+        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref.yaml").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
+                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 }

--- a/src/test/resources/swagger-enum-ref-wrong.json
+++ b/src/test/resources/swagger-enum-ref-wrong.json
@@ -1,0 +1,85 @@
+{
+	"swagger": "2.0",
+	"info": {
+		"description": "This is a sample server Petstore server.\n\n[Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.\n\nFor this sample, you can use the api key `special-key` to test the authorization filters\n",
+		"version": "1.0.0",
+		"title": "Swagger Petstore",
+		"termsOfService": "http://helloreverb.com/terms/",
+		"contact": {
+			"name": "apiteam@wordnik.com"
+		},
+		"license": {
+			"name": "Apache 2.0",
+			"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+		}
+	},
+	"host": "petstore.swagger.wordnik.com",
+	"basePath": "/v2",
+	"schemes": [
+		"http"
+	],
+	"paths": {
+		"/users/{username}": {
+			"get": {
+				"tags": [
+					"user"
+				],
+				"summary": "Get user by user name",
+				"description": "",
+				"operationId": "getUserByName",
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "username",
+						"description": "The name that needs to be fetched. Use user1 for testing.",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"schema": {
+							"$ref": "#/definitions/User"
+						}
+					},
+					"400": {
+						"description": "Invalid username supplied"
+					},
+					"404": {
+						"description": "User not found"
+					}
+				}
+			}
+		}
+	},
+	"definitions": {
+		"User": {
+			"properties": {
+				"id": {
+					"type": "integer",
+					"format": "int64"
+				},
+				"username": {
+					"type": "string"
+				},
+				"role": {
+					"$ref": "#/definitions/Role"
+				}
+			}
+		},
+		"Role": {
+			"description": "type: string enum: [ADMIN, USER, AUDITOR_WRONG]",
+			"type": "string",
+			"enum": [
+				"ADMIN",
+				"USER",
+				"AUDITOR_WRONG"
+			]
+		}
+	}
+}

--- a/src/test/resources/swagger-enum-ref.json
+++ b/src/test/resources/swagger-enum-ref.json
@@ -1,0 +1,85 @@
+{
+	"swagger": "2.0",
+	"info": {
+		"description": "This is a sample server Petstore server.\n\n[Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.\n\nFor this sample, you can use the api key `special-key` to test the authorization filters\n",
+		"version": "1.0.0",
+		"title": "Swagger Petstore",
+		"termsOfService": "http://helloreverb.com/terms/",
+		"contact": {
+			"name": "apiteam@wordnik.com"
+		},
+		"license": {
+			"name": "Apache 2.0",
+			"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+		}
+	},
+	"host": "petstore.swagger.wordnik.com",
+	"basePath": "/v2",
+	"schemes": [
+		"http"
+	],
+	"paths": {
+		"/users/{username}": {
+			"get": {
+				"tags": [
+					"user"
+				],
+				"summary": "Get user by user name",
+				"description": "",
+				"operationId": "getUserByName",
+				"produces": [
+					"application/json",
+					"application/xml"
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "username",
+						"description": "The name that needs to be fetched. Use user1 for testing.",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"schema": {
+							"$ref": "#/definitions/User"
+						}
+					},
+					"400": {
+						"description": "Invalid username supplied"
+					},
+					"404": {
+						"description": "User not found"
+					}
+				}
+			}
+		}
+	},
+	"definitions": {
+		"User": {
+			"properties": {
+				"id": {
+					"type": "integer",
+					"format": "int64"
+				},
+				"username": {
+					"type": "string"
+				},
+				"role": {
+					"$ref": "#/definitions/Role"
+				}
+			}
+		},
+		"Role": {
+			"description": "type: string enum: [ADMIN, USER, AUDITOR]",
+			"type": "string",
+			"enum": [
+				"ADMIN",
+				"USER",
+				"AUDITOR"
+			]
+		}
+	}
+}

--- a/src/test/resources/swagger-enum-ref.yaml
+++ b/src/test/resources/swagger-enum-ref.yaml
@@ -1,0 +1,65 @@
+swagger: "2.0"
+info:
+  description: |
+    This is a sample server Petstore server.
+
+    [Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.
+
+    For this sample, you can use the api key `special-key` to test the authorization filters
+  version: "1.0.0"
+  title: Swagger Petstore
+  termsOfService: http://helloreverb.com/terms/
+  contact:
+    name: apiteam@wordnik.com
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.wordnik.com
+basePath: /v2
+schemes:
+  - http
+paths:
+  /users/{username}:
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ""
+      operationId: getUserByName
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: username
+          description: The name that needs to be fetched. Use user1 for testing.
+          required: true
+          type: string
+      responses:
+        "404":
+          description: User not found
+        "200":
+          description: successful operation
+          schema:
+            $ref: "#/definitions/User"
+        "400":
+          description: Invalid username supplied
+definitions:
+  User:
+    properties:
+      id:
+        type: integer
+        format: int64
+      username:
+        type: string
+      role:
+        $ref: '#/definitions/Role'
+  Role:
+    description: 'type: string enum: [ADMIN, USER, AUDITOR]'
+    type: string
+    enum:
+      - ADMIN
+      - USER
+      - AUDITOR
+        
+        


### PR DESCRIPTION
Hi,
There was missing for me validation of enums which are defined in definitions section and they are used through reference.
I added this validation to place which seems to me as a good place.
If there is better place give me info where. Thanks.