### PR TITLE
feature/bytearrayproperty-validation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -227,6 +227,7 @@ The following overrides are available:
 ** `assertj.swagger.validateProperties=false`: disable validation of properties of definitions
 *** `assertj.swagger.validateRefProperties=false`: disable validation of reference (`$ref`) properties of definitions
 *** `assertj.swagger.validateArrayProperties=false`: disable validation of array properties of definitions
+*** `assertj.swagger.validateByteArrayProperties=false`: disable validation of byte-array properties of definitions
 *** `assertj.swagger.validateStringProperties=false`: disable validation of string properties of definitions
 ** `assertj.swagger.validateModels=false`: disable validation of models
 * `assertj.swagger.validatePaths=false`: disable all validation of endpoint definitions

--- a/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
@@ -18,13 +18,6 @@
  */
 package io.github.robwin.swagger.test;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import io.swagger.models.ArrayModel;
 import io.swagger.models.ComposedModel;
 import io.swagger.models.Info;
@@ -43,19 +36,25 @@ import io.swagger.models.parameters.Parameter;
 import io.swagger.models.parameters.PathParameter;
 import io.swagger.models.parameters.QueryParameter;
 import io.swagger.models.parameters.RefParameter;
-import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.Property;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.assertj.core.api.SoftAssertions;
 
 class DocumentationDrivenValidator extends AbstractContractValidator {
 
-    private SoftAssertions softAssertions;
+    private static final String[] TYPE_DEFINING_PROPERTIES = {"type", "format"};
 
     private SwaggerAssertionConfig assertionConfig;
+    private SoftAssertions softAssertions;
+    private PropertyValidator propertyValidator;
+
     private Swagger actual;
     private SchemaObjectResolver schemaObjectResolver;   // provide means to fall back from local to global properties
 
@@ -63,6 +62,7 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         this.actual = actual;
         this.assertionConfig = assertionConfig;
         softAssertions = new SoftAssertions();
+        propertyValidator = new PropertyValidator(assertionConfig, softAssertions);
     }
 
     @Override
@@ -92,7 +92,8 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
 
         // Version.  OFF by default.
         if (isAssertionEnabled(SwaggerAssertionType.VERSION)) {
-            softAssertions.assertThat(actualInfo.getVersion()).as("Checking Version").isEqualTo(expectedInfo.getVersion());
+            softAssertions.assertThat(actualInfo.getVersion()).as("Checking Version")
+                .isEqualTo(expectedInfo.getVersion());
         }
 
         // Everything (but potentially brittle, therefore OFF by default)
@@ -105,7 +106,8 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         if (MapUtils.isNotEmpty(expectedPaths)) {
             softAssertions.assertThat(actualPaths).as("Checking Paths").isNotEmpty();
             if (MapUtils.isNotEmpty(actualPaths)) {
-                softAssertions.assertThat(actualPaths.keySet()).as("Checking Paths").hasSameElementsAs(expectedPaths.keySet());
+                softAssertions.assertThat(actualPaths.keySet()).as("Checking Paths")
+                    .hasSameElementsAs(expectedPaths.keySet());
                 for (Map.Entry<String, Path> actualPathEntry : actualPaths.entrySet()) {
                     Path expectedPath = expectedPaths.get(actualPathEntry.getKey());
                     Path actualPath = actualPathEntry.getValue();
@@ -122,7 +124,8 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         if (MapUtils.isNotEmpty(expectedDefinitions)) {
             softAssertions.assertThat(actualDefinitions).as("Checking Definitions").isNotEmpty();
             if (MapUtils.isNotEmpty(actualDefinitions)) {
-                softAssertions.assertThat(actualDefinitions.keySet()).as("Checking Definitions").hasSameElementsAs(expectedDefinitions.keySet());
+                softAssertions.assertThat(actualDefinitions.keySet()).as("Checking Definitions")
+                    .hasSameElementsAs(expectedDefinitions.keySet());
                 for (Map.Entry<String, Model> actualDefinitionEntry : actualDefinitions.entrySet()) {
                     Model expectedDefinition = expectedDefinitions.get(actualDefinitionEntry.getKey());
                     Model actualDefinition = actualDefinitionEntry.getValue();
@@ -137,7 +140,8 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
 
     private void validatePath(String pathName, Path actualPath, Path expectedPath) {
         if (expectedPath != null) {
-            softAssertions.assertThat(actualPath.getOperations()).as("Checking number of operations of path '%s'", pathName).hasSameSizeAs(actualPath.getOperations());
+            softAssertions.assertThat(actualPath.getOperations())
+                .as("Checking number of operations of path '%s'", pathName).hasSameSizeAs(actualPath.getOperations());
             validateOperation(actualPath.getGet(), expectedPath.getGet(), pathName, "GET");
             validateOperation(actualPath.getDelete(), expectedPath.getDelete(), pathName, "DELETE");
             validateOperation(actualPath.getPost(), expectedPath.getPost(), pathName, "POST");
@@ -149,23 +153,32 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
 
     private void validateDefinition(String definitionName, Model actualDefinition, Model expectedDefinition) {
         if (expectedDefinition != null && actualDefinition != null) {
-            validateModel(actualDefinition, expectedDefinition, String.format("Checking model of definition '%s", definitionName));
+            validateModel(actualDefinition, expectedDefinition,
+                String.format("Checking model of definition '%s", definitionName));
             validateDefinitionProperties(schemaObjectResolver.resolvePropertiesFromActual(actualDefinition),
-                                         schemaObjectResolver.resolvePropertiesFromExpected(expectedDefinition),
-                                         definitionName);
+                schemaObjectResolver.resolvePropertiesFromExpected(expectedDefinition),
+                definitionName);
 
             if (expectedDefinition instanceof ModelImpl && actualDefinition instanceof ModelImpl) {
+                validateTypeDefinition(actualDefinition, expectedDefinition);
                 validateDefinitionEnum(actualDefinition, expectedDefinition);
                 validateDefinitionRequiredProperties(((ModelImpl) actualDefinition).getRequired(),
-                                                     ((ModelImpl) expectedDefinition).getRequired(),
-                                                       definitionName);
+                    ((ModelImpl) expectedDefinition).getRequired(),
+                    definitionName);
             }
         }
     }
 
+    private void validateTypeDefinition(Model actualDefinition, Model expectedDefinition) {
+        ModelImpl expectedDefModelImpl = (ModelImpl) expectedDefinition;
+        ModelImpl actualDefModelImpl = (ModelImpl) actualDefinition;
+        softAssertions.assertThat(actualDefModelImpl)
+            .isEqualToComparingOnlyGivenFields(expectedDefModelImpl, TYPE_DEFINING_PROPERTIES);
+    }
+
     private void validateDefinitionEnum(Model actualDefinition, Model expectedDefinition) {
-        ModelImpl expectedDefModelImpl = (ModelImpl)expectedDefinition;
-        ModelImpl actualDefModelImpl = (ModelImpl)actualDefinition;
+        ModelImpl expectedDefModelImpl = (ModelImpl) expectedDefinition;
+        ModelImpl actualDefModelImpl = (ModelImpl) actualDefinition;
         List<String> actualEnums = actualDefModelImpl.getEnum();
         List<String> expectedEnums = expectedDefModelImpl.getEnum();
         if (CollectionUtils.isNotEmpty(expectedEnums)) {
@@ -175,15 +188,21 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         }
     }
 
-    private void validateDefinitionRequiredProperties(List<String> actualRequiredProperties, List<String> expectedRequiredProperties, String definitionName) {
+    private void validateDefinitionRequiredProperties(List<String> actualRequiredProperties,
+        List<String> expectedRequiredProperties, String definitionName) {
         if (CollectionUtils.isNotEmpty(expectedRequiredProperties)) {
-            softAssertions.assertThat(actualRequiredProperties).as("Checking required properties of definition '%s'", definitionName).isNotEmpty();
+            softAssertions.assertThat(actualRequiredProperties)
+                .as("Checking required properties of definition '%s'", definitionName).isNotEmpty();
             if (CollectionUtils.isNotEmpty(actualRequiredProperties)) {
-                final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName, new HashSet<>(expectedRequiredProperties));
-                softAssertions.assertThat(actualRequiredProperties).as("Checking required properties of definition '%s'", definitionName).hasSameElementsAs(filteredExpectedProperties);
+                final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName,
+                    new HashSet<>(expectedRequiredProperties));
+                softAssertions.assertThat(actualRequiredProperties)
+                    .as("Checking required properties of definition '%s'", definitionName)
+                    .hasSameElementsAs(filteredExpectedProperties);
             }
         } else {
-            softAssertions.assertThat(actualRequiredProperties).as("Checking required properties of definition '%s'", definitionName).isNullOrEmpty();
+            softAssertions.assertThat(actualRequiredProperties)
+                .as("Checking required properties of definition '%s'", definitionName).isNullOrEmpty();
         }
     }
 
@@ -201,7 +220,8 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
                 softAssertions.assertThat(actualDefinition).as(message).isExactlyInstanceOf(ArrayModel.class);
             } else if (expectedDefinition instanceof ComposedModel) {
                 ComposedModel composedModel = (ComposedModel) expectedDefinition;
-                softAssertions.assertThat(actualDefinition).as(message).isInstanceOfAny(ComposedModel.class, ModelImpl.class);
+                softAssertions.assertThat(actualDefinition).as(message)
+                    .isInstanceOfAny(ComposedModel.class, ModelImpl.class);
             } else {
                 // TODO Validate all model types
                 softAssertions.assertThat(actualDefinition).isExactlyInstanceOf(expectedDefinition.getClass());
@@ -209,77 +229,54 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         }
     }
 
-    private void validateDefinitionProperties(Map<String, Property> actualDefinitionProperties, Map<String, Property> expectedDefinitionProperties, String definitionName) {
+    private void validateDefinitionProperties(Map<String, Property> actualDefinitionProperties,
+        Map<String, Property> expectedDefinitionProperties, String definitionName) {
         if (MapUtils.isNotEmpty(expectedDefinitionProperties)) {
-            softAssertions.assertThat(actualDefinitionProperties).as("Checking properties of definition '%s", definitionName).isNotEmpty();
+            softAssertions.assertThat(actualDefinitionProperties)
+                .as("Checking properties of definition '%s", definitionName).isNotEmpty();
             if (MapUtils.isNotEmpty(actualDefinitionProperties)) {
-                final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName, expectedDefinitionProperties.keySet());
-                softAssertions.assertThat(actualDefinitionProperties.keySet()).as("Checking properties of definition '%s'", definitionName).hasSameElementsAs(filteredExpectedProperties);
-                for (Map.Entry<String, Property> actualDefinitionPropertyEntry : actualDefinitionProperties.entrySet()) {
-                    Property expectedDefinitionProperty = expectedDefinitionProperties.get(actualDefinitionPropertyEntry.getKey());
+                final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName,
+                    expectedDefinitionProperties.keySet());
+                softAssertions.assertThat(actualDefinitionProperties.keySet())
+                    .as("Checking properties of definition '%s'", definitionName)
+                    .hasSameElementsAs(filteredExpectedProperties);
+                for (Map.Entry<String, Property> actualDefinitionPropertyEntry : actualDefinitionProperties
+                    .entrySet()) {
+                    Property expectedDefinitionProperty = expectedDefinitionProperties
+                        .get(actualDefinitionPropertyEntry.getKey());
                     Property actualDefinitionProperty = actualDefinitionPropertyEntry.getValue();
                     String propertyName = actualDefinitionPropertyEntry.getKey();
-                    validateProperty(actualDefinitionProperty, expectedDefinitionProperty, String.format("Checking property '%s' of definition '%s'", propertyName, definitionName));
+                    validateProperty(actualDefinitionProperty, expectedDefinitionProperty,
+                        String.format("Checking property '%s' of definition '%s'", propertyName, definitionName));
                 }
             }
         } else {
-            softAssertions.assertThat(actualDefinitionProperties).as("Checking properties of definition '%s", definitionName).isNullOrEmpty();
+            softAssertions.assertThat(actualDefinitionProperties)
+                .as("Checking properties of definition '%s", definitionName).isNullOrEmpty();
         }
     }
 
     private void validateProperty(Property actualProperty, Property expectedProperty, String message) {
-        // TODO Validate Property schema
-        if (expectedProperty != null && isAssertionEnabled(SwaggerAssertionType.PROPERTIES)) {
-            if (expectedProperty instanceof RefProperty) {
-                if (isAssertionEnabled(SwaggerAssertionType.REF_PROPERTIES)) {
-                    RefProperty refProperty = (RefProperty) expectedProperty;
-                    softAssertions.assertThat(actualProperty).as(message).isExactlyInstanceOf(RefProperty.class);
-                    // TODO Validate RefProperty
-                }
-            } else if (expectedProperty instanceof ArrayProperty) {
-                if (isAssertionEnabled(SwaggerAssertionType.ARRAY_PROPERTIES)) {
-                    ArrayProperty arrayProperty = (ArrayProperty) expectedProperty;
-                    softAssertions.assertThat(actualProperty).as(message).isExactlyInstanceOf(ArrayProperty.class);
-                    // TODO Validate ArrayProperty
-                }
-            } else if (expectedProperty instanceof StringProperty) {
-                if (isAssertionEnabled(SwaggerAssertionType.STRING_PROPERTIES)) {
-                    StringProperty expectedStringProperty = (StringProperty) expectedProperty;
-                    softAssertions.assertThat(actualProperty).as(message).isExactlyInstanceOf(StringProperty.class);
-                    // TODO Validate StringProperty
-                    if (actualProperty instanceof StringProperty) {
-                        StringProperty actualStringProperty = (StringProperty) actualProperty;
-                        List<String> expectedEnums = expectedStringProperty.getEnum();
-                        if (CollectionUtils.isNotEmpty(expectedEnums)) {
-                            softAssertions.assertThat(actualStringProperty.getEnum()).hasSameElementsAs(expectedEnums);
-                        } else {
-                            softAssertions.assertThat(actualStringProperty.getEnum()).isNullOrEmpty();
-                        }
-                    }
-                }
-            } else {
-                // TODO Validate all other properties
-                softAssertions.assertThat(actualProperty).as(message).isExactlyInstanceOf(expectedProperty.getClass());
-            }
-        }
-
+        propertyValidator.validateProperty(actualProperty, expectedProperty, message);
     }
 
-    private void validateOperation(Operation actualOperation, Operation expectedOperation, String path, String httpMethod) {
+    private void validateOperation(Operation actualOperation, Operation expectedOperation, String path,
+        String httpMethod) {
         String message = String.format("Checking '%s' operation of path '%s'", httpMethod, path);
         if (expectedOperation != null) {
             softAssertions.assertThat(actualOperation).as(message).isNotNull();
             if (actualOperation != null) {
                 //Validate consumes
                 validateList(schemaObjectResolver.getActualConsumes(actualOperation),
-                        schemaObjectResolver.getExpectedConsumes(expectedOperation),
-                        String.format("Checking '%s' of '%s' operation of path '%s'", "consumes", httpMethod, path));
+                    schemaObjectResolver.getExpectedConsumes(expectedOperation),
+                    String.format("Checking '%s' of '%s' operation of path '%s'", "consumes", httpMethod, path));
                 //Validate produces
                 validateList(schemaObjectResolver.getActualProduces(actualOperation),
-                        schemaObjectResolver.getExpectedProduces(expectedOperation),
-                        String.format("Checking '%s' of '%s' operation of path '%s'", "produces", httpMethod, path));
+                    schemaObjectResolver.getExpectedProduces(expectedOperation),
+                    String.format("Checking '%s' of '%s' operation of path '%s'", "produces", httpMethod, path));
                 //Validate parameters
-                validateParameters(actualOperation.getParameters(), expectedOperation.getParameters(), httpMethod, path);
+                validateParameters(actualOperation.getParameters(), expectedOperation.getParameters(), httpMethod,
+                    path);
                 //Validate responses
                 validateResponses(actualOperation.getResponses(), expectedOperation.getResponses(), httpMethod, path);
             }
@@ -288,13 +285,17 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         }
     }
 
-    private void validateParameters(List<Parameter> actualOperationParameters,  List<Parameter> expectedOperationParameters, String httpMethod, String path) {
+    private void validateParameters(List<Parameter> actualOperationParameters,
+        List<Parameter> expectedOperationParameters, String httpMethod, String path) {
         String message = String.format("Checking parameters of '%s' operation of path '%s'", httpMethod, path);
         if (CollectionUtils.isNotEmpty(expectedOperationParameters)) {
             softAssertions.assertThat(actualOperationParameters).as(message).isNotEmpty();
             if (CollectionUtils.isNotEmpty(actualOperationParameters)) {
-                softAssertions.assertThat(actualOperationParameters).as(message).hasSameSizeAs(expectedOperationParameters);
-                softAssertions.assertThat(actualOperationParameters).as(message).usingElementComparatorOnFields("in", "name", "required").hasSameElementsAs(expectedOperationParameters);
+                softAssertions.assertThat(actualOperationParameters).as(message)
+                    .hasSameSizeAs(expectedOperationParameters);
+                softAssertions.assertThat(actualOperationParameters).as(message)
+                    .usingElementComparatorOnFields("in", "name", "required")
+                    .hasSameElementsAs(expectedOperationParameters);
                 Map<String, Parameter> expectedParametersAsMap = new HashMap<>();
                 for (Parameter expectedParameter : expectedOperationParameters) {
                     expectedParametersAsMap.put(expectedParameter.getName(), expectedParameter);
@@ -310,73 +311,89 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         }
     }
 
-    private void validateParameter(Parameter actualParameter, Parameter expectedParameter, String parameterName, String httpMethod, String path) {
+    private void validateParameter(Parameter actualParameter, Parameter expectedParameter, String parameterName,
+        String httpMethod, String path) {
         if (expectedParameter != null) {
-            String message = String.format("Checking parameter '%s' of '%s' operation of path '%s'", parameterName, httpMethod, path);
+            String message = String
+                .format("Checking parameter '%s' of '%s' operation of path '%s'", parameterName, httpMethod, path);
             softAssertions.assertThat(actualParameter).as(message).isExactlyInstanceOf(expectedParameter.getClass());
             if (expectedParameter instanceof BodyParameter && actualParameter instanceof BodyParameter) {
                 BodyParameter actualBodyParameter = (BodyParameter) expectedParameter;
                 BodyParameter expectedBodyParameter = (BodyParameter) expectedParameter;
-                validateModel(actualBodyParameter.getSchema(), expectedBodyParameter.getSchema(), String.format("Checking model of parameter '%s' of '%s' operation of path '%s'", parameterName, httpMethod, path));
+                validateModel(actualBodyParameter.getSchema(), expectedBodyParameter.getSchema(), String
+                    .format("Checking model of parameter '%s' of '%s' operation of path '%s'", parameterName,
+                        httpMethod, path));
             } else if (expectedParameter instanceof PathParameter && actualParameter instanceof PathParameter) {
                 PathParameter actualPathParameter = (PathParameter) actualParameter;
                 PathParameter expectedPathParameter = (PathParameter) expectedParameter;
-                softAssertions.assertThat(actualPathParameter.getType()).as(message).isEqualTo(expectedPathParameter.getType());
+                softAssertions.assertThat(actualPathParameter.getType()).as(message)
+                    .isEqualTo(expectedPathParameter.getType());
                 List<String> expectedEnums = expectedPathParameter.getEnum();
                 if (CollectionUtils.isNotEmpty(expectedEnums)) {
-                    softAssertions.assertThat(actualPathParameter.getEnum()).as(message).hasSameElementsAs(expectedEnums);
+                    softAssertions.assertThat(actualPathParameter.getEnum()).as(message)
+                        .hasSameElementsAs(expectedEnums);
                 } else {
                     softAssertions.assertThat(actualPathParameter.getEnum()).as(message).isNullOrEmpty();
                 }
             } else if (expectedParameter instanceof QueryParameter && actualParameter instanceof QueryParameter) {
                 QueryParameter actualQueryParameter = (QueryParameter) actualParameter;
                 QueryParameter expectedQueryParameter = (QueryParameter) expectedParameter;
-                softAssertions.assertThat(actualQueryParameter.getType()).as(message).isEqualTo(expectedQueryParameter.getType());
+                softAssertions.assertThat(actualQueryParameter.getType()).as(message)
+                    .isEqualTo(expectedQueryParameter.getType());
                 List<String> expectedEnums = expectedQueryParameter.getEnum();
                 if (CollectionUtils.isNotEmpty(expectedEnums)) {
-                    softAssertions.assertThat(actualQueryParameter.getEnum()).as(message).hasSameElementsAs(expectedEnums);
+                    softAssertions.assertThat(actualQueryParameter.getEnum()).as(message)
+                        .hasSameElementsAs(expectedEnums);
                 } else {
                     softAssertions.assertThat(actualQueryParameter.getEnum()).as(message).isNullOrEmpty();
                 }
             } else if (expectedParameter instanceof HeaderParameter && actualParameter instanceof HeaderParameter) {
                 HeaderParameter actualHeaderParameter = (HeaderParameter) actualParameter;
                 HeaderParameter expectedHeaderParameter = (HeaderParameter) expectedParameter;
-                softAssertions.assertThat(actualHeaderParameter.getType()).as(message).isEqualTo(expectedHeaderParameter.getType());
+                softAssertions.assertThat(actualHeaderParameter.getType()).as(message)
+                    .isEqualTo(expectedHeaderParameter.getType());
                 List<String> expectedEnums = expectedHeaderParameter.getEnum();
                 if (CollectionUtils.isNotEmpty(expectedEnums)) {
-                    softAssertions.assertThat(actualHeaderParameter.getEnum()).as(message).hasSameElementsAs(expectedEnums);
+                    softAssertions.assertThat(actualHeaderParameter.getEnum()).as(message)
+                        .hasSameElementsAs(expectedEnums);
                 } else {
                     softAssertions.assertThat(actualHeaderParameter.getEnum()).as(message).isNullOrEmpty();
                 }
             } else if (expectedParameter instanceof FormParameter && actualParameter instanceof FormParameter) {
                 FormParameter actualFormParameter = (FormParameter) actualParameter;
                 FormParameter expectedFormParameter = (FormParameter) expectedParameter;
-                softAssertions.assertThat(actualFormParameter.getType()).as(message).isEqualTo(expectedFormParameter.getType());
+                softAssertions.assertThat(actualFormParameter.getType()).as(message)
+                    .isEqualTo(expectedFormParameter.getType());
                 List<String> expectedEnums = expectedFormParameter.getEnum();
                 if (CollectionUtils.isNotEmpty(expectedEnums)) {
-                    softAssertions.assertThat(actualFormParameter.getEnum()).as(message).hasSameElementsAs(expectedEnums);
+                    softAssertions.assertThat(actualFormParameter.getEnum()).as(message)
+                        .hasSameElementsAs(expectedEnums);
                 } else {
                     softAssertions.assertThat(actualFormParameter.getEnum()).as(message).isNullOrEmpty();
                 }
             } else if (expectedParameter instanceof CookieParameter && actualParameter instanceof CookieParameter) {
                 CookieParameter actualCookieParameter = (CookieParameter) actualParameter;
                 CookieParameter expectedCookieParameter = (CookieParameter) expectedParameter;
-                softAssertions.assertThat(actualCookieParameter.getType()).as(message).isEqualTo(expectedCookieParameter.getType());
+                softAssertions.assertThat(actualCookieParameter.getType()).as(message)
+                    .isEqualTo(expectedCookieParameter.getType());
                 List<String> expectedEnums = expectedCookieParameter.getEnum();
                 if (CollectionUtils.isNotEmpty(expectedEnums)) {
-                    softAssertions.assertThat(actualCookieParameter.getEnum()).as(message).hasSameElementsAs(expectedEnums);
+                    softAssertions.assertThat(actualCookieParameter.getEnum()).as(message)
+                        .hasSameElementsAs(expectedEnums);
                 } else {
                     softAssertions.assertThat(actualCookieParameter.getEnum()).as(message).isNullOrEmpty();
                 }
             } else if (expectedParameter instanceof RefParameter && actualParameter instanceof RefParameter) {
                 RefParameter expectedRefParameter = (RefParameter) expectedParameter;
                 RefParameter actualRefParameter = (RefParameter) actualParameter;
-                softAssertions.assertThat(actualRefParameter.getSimpleRef()).as(message).isEqualTo(expectedRefParameter.getSimpleRef());
+                softAssertions.assertThat(actualRefParameter.getSimpleRef()).as(message)
+                    .isEqualTo(expectedRefParameter.getSimpleRef());
             }
         }
     }
 
-    private void validateResponses(Map<String, Response> actualOperationResponses, Map<String, Response> expectedOperationResponses, String httpMethod, String path) {
+    private void validateResponses(Map<String, Response> actualOperationResponses,
+        Map<String, Response> expectedOperationResponses, String httpMethod, String path) {
         String message = String.format("Checking responses of '%s' operation of path '%s'", httpMethod, path);
         if (MapUtils.isNotEmpty(expectedOperationResponses)) {
             softAssertions.assertThat(actualOperationResponses).as(message).isNotEmpty();
@@ -394,32 +411,45 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         }
     }
 
-    private void validateResponseByConfig(Map<String, Response> actualOperationResponses, Map<String, Response> expectedOperationResponses, String message) {
-        if(isAssertionEnabled(SwaggerAssertionType.STRICT_VALIDATION_ON_PATH)) {
-            softAssertions.assertThat(actualOperationResponses.keySet()).as(message).hasSameElementsAs(expectedOperationResponses.keySet());
+    private void validateResponseByConfig(Map<String, Response> actualOperationResponses,
+        Map<String, Response> expectedOperationResponses, String message) {
+        if (isAssertionEnabled(SwaggerAssertionType.STRICT_VALIDATION_ON_PATH)) {
+            softAssertions.assertThat(actualOperationResponses.keySet()).as(message)
+                .hasSameElementsAs(expectedOperationResponses.keySet());
         } else {
-            softAssertions.assertThat(actualOperationResponses.keySet()).as(message).containsAll(expectedOperationResponses.keySet());
+            softAssertions.assertThat(actualOperationResponses.keySet()).as(message)
+                .containsAll(expectedOperationResponses.keySet());
         }
     }
 
-    private void validateResponse(Response actualResponse, Response expectedResponse, String responseName, String httpMethod, String path) {
+    private void validateResponse(Response actualResponse, Response expectedResponse, String responseName,
+        String httpMethod, String path) {
         if (expectedResponse != null) {
-            validateProperty(actualResponse.getSchema(), expectedResponse.getSchema(), String.format("Checking response schema of response '%s' of '%s' operation of path '%s'", responseName, httpMethod, path));
-            validateResponseHeaders(actualResponse.getHeaders(), expectedResponse.getHeaders(), responseName, httpMethod, path);
+            validateProperty(actualResponse.getSchema(), expectedResponse.getSchema(), String
+                .format("Checking response schema of response '%s' of '%s' operation of path '%s'", responseName,
+                    httpMethod, path));
+            validateResponseHeaders(actualResponse.getHeaders(), expectedResponse.getHeaders(), responseName,
+                httpMethod, path);
         }
     }
 
-    private void validateResponseHeaders(Map<String, Property> actualResponseHeaders, Map<String, Property> expectedResponseHeaders, String responseName, String httpMethod, String path) {
-        String message = String.format("Checking response headers of response '%s' of '%s' operation of path '%s'", responseName, httpMethod, path);
+    private void validateResponseHeaders(Map<String, Property> actualResponseHeaders,
+        Map<String, Property> expectedResponseHeaders, String responseName, String httpMethod, String path) {
+        String message = String
+            .format("Checking response headers of response '%s' of '%s' operation of path '%s'", responseName,
+                httpMethod, path);
         if (MapUtils.isNotEmpty(expectedResponseHeaders)) {
             softAssertions.assertThat(actualResponseHeaders).as(message).isNotEmpty();
             if (MapUtils.isNotEmpty(actualResponseHeaders)) {
-                softAssertions.assertThat(actualResponseHeaders.keySet()).as(message).hasSameElementsAs(expectedResponseHeaders.keySet());
+                softAssertions.assertThat(actualResponseHeaders.keySet()).as(message)
+                    .hasSameElementsAs(expectedResponseHeaders.keySet());
                 for (Map.Entry<String, Property> actualResponseHeaderEntry : actualResponseHeaders.entrySet()) {
                     Property expectedResponseHeader = expectedResponseHeaders.get(actualResponseHeaderEntry.getKey());
                     Property actualResponseHeader = actualResponseHeaderEntry.getValue();
                     String responseHeaderName = actualResponseHeaderEntry.getKey();
-                    validateProperty(actualResponseHeader, expectedResponseHeader, String.format("Checking response header '%s' of response '%s' of '%s' operation of path '%s'", responseHeaderName, responseName, httpMethod, path));
+                    validateProperty(actualResponseHeader, expectedResponseHeader, String
+                        .format("Checking response header '%s' of response '%s' of '%s' operation of path '%s'",
+                            responseHeaderName, responseName, httpMethod, path));
                 }
             }
         } else {

--- a/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/DocumentationDrivenValidator.java
@@ -92,8 +92,7 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
 
         // Version.  OFF by default.
         if (isAssertionEnabled(SwaggerAssertionType.VERSION)) {
-            softAssertions.assertThat(actualInfo.getVersion()).as("Checking Version")
-                .isEqualTo(expectedInfo.getVersion());
+            softAssertions.assertThat(actualInfo.getVersion()).as("Checking Version").isEqualTo(expectedInfo.getVersion());
         }
 
         // Everything (but potentially brittle, therefore OFF by default)
@@ -106,8 +105,7 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         if (MapUtils.isNotEmpty(expectedPaths)) {
             softAssertions.assertThat(actualPaths).as("Checking Paths").isNotEmpty();
             if (MapUtils.isNotEmpty(actualPaths)) {
-                softAssertions.assertThat(actualPaths.keySet()).as("Checking Paths")
-                    .hasSameElementsAs(expectedPaths.keySet());
+                softAssertions.assertThat(actualPaths.keySet()).as("Checking Paths").hasSameElementsAs(expectedPaths.keySet());
                 for (Map.Entry<String, Path> actualPathEntry : actualPaths.entrySet()) {
                     Path expectedPath = expectedPaths.get(actualPathEntry.getKey());
                     Path actualPath = actualPathEntry.getValue();
@@ -124,8 +122,7 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         if (MapUtils.isNotEmpty(expectedDefinitions)) {
             softAssertions.assertThat(actualDefinitions).as("Checking Definitions").isNotEmpty();
             if (MapUtils.isNotEmpty(actualDefinitions)) {
-                softAssertions.assertThat(actualDefinitions.keySet()).as("Checking Definitions")
-                    .hasSameElementsAs(expectedDefinitions.keySet());
+                softAssertions.assertThat(actualDefinitions.keySet()).as("Checking Definitions").hasSameElementsAs(expectedDefinitions.keySet());
                 for (Map.Entry<String, Model> actualDefinitionEntry : actualDefinitions.entrySet()) {
                     Model expectedDefinition = expectedDefinitions.get(actualDefinitionEntry.getKey());
                     Model actualDefinition = actualDefinitionEntry.getValue();
@@ -140,8 +137,7 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
 
     private void validatePath(String pathName, Path actualPath, Path expectedPath) {
         if (expectedPath != null) {
-            softAssertions.assertThat(actualPath.getOperations())
-                .as("Checking number of operations of path '%s'", pathName).hasSameSizeAs(actualPath.getOperations());
+            softAssertions.assertThat(actualPath.getOperations()).as("Checking number of operations of path '%s'", pathName).hasSameSizeAs(actualPath.getOperations());
             validateOperation(actualPath.getGet(), expectedPath.getGet(), pathName, "GET");
             validateOperation(actualPath.getDelete(), expectedPath.getDelete(), pathName, "DELETE");
             validateOperation(actualPath.getPost(), expectedPath.getPost(), pathName, "POST");
@@ -153,18 +149,17 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
 
     private void validateDefinition(String definitionName, Model actualDefinition, Model expectedDefinition) {
         if (expectedDefinition != null && actualDefinition != null) {
-            validateModel(actualDefinition, expectedDefinition,
-                String.format("Checking model of definition '%s", definitionName));
+            validateModel(actualDefinition, expectedDefinition, String.format("Checking model of definition '%s", definitionName));
             validateDefinitionProperties(schemaObjectResolver.resolvePropertiesFromActual(actualDefinition),
-                schemaObjectResolver.resolvePropertiesFromExpected(expectedDefinition),
-                definitionName);
+                                         schemaObjectResolver.resolvePropertiesFromExpected(expectedDefinition),
+                                         definitionName);
 
             if (expectedDefinition instanceof ModelImpl && actualDefinition instanceof ModelImpl) {
                 validateTypeDefinition(actualDefinition, expectedDefinition);
                 validateDefinitionEnum(actualDefinition, expectedDefinition);
                 validateDefinitionRequiredProperties(((ModelImpl) actualDefinition).getRequired(),
-                    ((ModelImpl) expectedDefinition).getRequired(),
-                    definitionName);
+                                                     ((ModelImpl) expectedDefinition).getRequired(),
+                                                       definitionName);
             }
         }
     }
@@ -188,21 +183,15 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         }
     }
 
-    private void validateDefinitionRequiredProperties(List<String> actualRequiredProperties,
-        List<String> expectedRequiredProperties, String definitionName) {
+    private void validateDefinitionRequiredProperties(List<String> actualRequiredProperties, List<String> expectedRequiredProperties, String definitionName) {
         if (CollectionUtils.isNotEmpty(expectedRequiredProperties)) {
-            softAssertions.assertThat(actualRequiredProperties)
-                .as("Checking required properties of definition '%s'", definitionName).isNotEmpty();
+            softAssertions.assertThat(actualRequiredProperties).as("Checking required properties of definition '%s'", definitionName).isNotEmpty();
             if (CollectionUtils.isNotEmpty(actualRequiredProperties)) {
-                final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName,
-                    new HashSet<>(expectedRequiredProperties));
-                softAssertions.assertThat(actualRequiredProperties)
-                    .as("Checking required properties of definition '%s'", definitionName)
-                    .hasSameElementsAs(filteredExpectedProperties);
+                final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName, new HashSet<>(expectedRequiredProperties));
+                softAssertions.assertThat(actualRequiredProperties).as("Checking required properties of definition '%s'", definitionName).hasSameElementsAs(filteredExpectedProperties);
             }
         } else {
-            softAssertions.assertThat(actualRequiredProperties)
-                .as("Checking required properties of definition '%s'", definitionName).isNullOrEmpty();
+            softAssertions.assertThat(actualRequiredProperties).as("Checking required properties of definition '%s'", definitionName).isNullOrEmpty();
         }
     }
 
@@ -220,8 +209,7 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
                 softAssertions.assertThat(actualDefinition).as(message).isExactlyInstanceOf(ArrayModel.class);
             } else if (expectedDefinition instanceof ComposedModel) {
                 ComposedModel composedModel = (ComposedModel) expectedDefinition;
-                softAssertions.assertThat(actualDefinition).as(message)
-                    .isInstanceOfAny(ComposedModel.class, ModelImpl.class);
+                softAssertions.assertThat(actualDefinition).as(message).isInstanceOfAny(ComposedModel.class, ModelImpl.class);
             } else {
                 // TODO Validate all model types
                 softAssertions.assertThat(actualDefinition).isExactlyInstanceOf(expectedDefinition.getClass());
@@ -229,30 +217,21 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         }
     }
 
-    private void validateDefinitionProperties(Map<String, Property> actualDefinitionProperties,
-        Map<String, Property> expectedDefinitionProperties, String definitionName) {
+    private void validateDefinitionProperties(Map<String, Property> actualDefinitionProperties, Map<String, Property> expectedDefinitionProperties, String definitionName) {
         if (MapUtils.isNotEmpty(expectedDefinitionProperties)) {
-            softAssertions.assertThat(actualDefinitionProperties)
-                .as("Checking properties of definition '%s", definitionName).isNotEmpty();
+            softAssertions.assertThat(actualDefinitionProperties).as("Checking properties of definition '%s", definitionName).isNotEmpty();
             if (MapUtils.isNotEmpty(actualDefinitionProperties)) {
-                final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName,
-                    expectedDefinitionProperties.keySet());
-                softAssertions.assertThat(actualDefinitionProperties.keySet())
-                    .as("Checking properties of definition '%s'", definitionName)
-                    .hasSameElementsAs(filteredExpectedProperties);
-                for (Map.Entry<String, Property> actualDefinitionPropertyEntry : actualDefinitionProperties
-                    .entrySet()) {
-                    Property expectedDefinitionProperty = expectedDefinitionProperties
-                        .get(actualDefinitionPropertyEntry.getKey());
+                final Set<String> filteredExpectedProperties = filterWhitelistedPropertyNames(definitionName, expectedDefinitionProperties.keySet());
+                softAssertions.assertThat(actualDefinitionProperties.keySet()).as("Checking properties of definition '%s'", definitionName).hasSameElementsAs(filteredExpectedProperties);
+                for (Map.Entry<String, Property> actualDefinitionPropertyEntry : actualDefinitionProperties.entrySet()) {
+                    Property expectedDefinitionProperty = expectedDefinitionProperties.get(actualDefinitionPropertyEntry.getKey());
                     Property actualDefinitionProperty = actualDefinitionPropertyEntry.getValue();
                     String propertyName = actualDefinitionPropertyEntry.getKey();
-                    validateProperty(actualDefinitionProperty, expectedDefinitionProperty,
-                        String.format("Checking property '%s' of definition '%s'", propertyName, definitionName));
+                    validateProperty(actualDefinitionProperty, expectedDefinitionProperty, String.format("Checking property '%s' of definition '%s'", propertyName, definitionName));
                 }
             }
         } else {
-            softAssertions.assertThat(actualDefinitionProperties)
-                .as("Checking properties of definition '%s", definitionName).isNullOrEmpty();
+            softAssertions.assertThat(actualDefinitionProperties).as("Checking properties of definition '%s", definitionName).isNullOrEmpty();
         }
     }
 
@@ -260,23 +239,21 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         propertyValidator.validateProperty(actualProperty, expectedProperty, message);
     }
 
-    private void validateOperation(Operation actualOperation, Operation expectedOperation, String path,
-        String httpMethod) {
+    private void validateOperation(Operation actualOperation, Operation expectedOperation, String path, String httpMethod) {
         String message = String.format("Checking '%s' operation of path '%s'", httpMethod, path);
         if (expectedOperation != null) {
             softAssertions.assertThat(actualOperation).as(message).isNotNull();
             if (actualOperation != null) {
                 //Validate consumes
                 validateList(schemaObjectResolver.getActualConsumes(actualOperation),
-                    schemaObjectResolver.getExpectedConsumes(expectedOperation),
-                    String.format("Checking '%s' of '%s' operation of path '%s'", "consumes", httpMethod, path));
+                        schemaObjectResolver.getExpectedConsumes(expectedOperation),
+                        String.format("Checking '%s' of '%s' operation of path '%s'", "consumes", httpMethod, path));
                 //Validate produces
                 validateList(schemaObjectResolver.getActualProduces(actualOperation),
-                    schemaObjectResolver.getExpectedProduces(expectedOperation),
-                    String.format("Checking '%s' of '%s' operation of path '%s'", "produces", httpMethod, path));
+                        schemaObjectResolver.getExpectedProduces(expectedOperation),
+                        String.format("Checking '%s' of '%s' operation of path '%s'", "produces", httpMethod, path));
                 //Validate parameters
-                validateParameters(actualOperation.getParameters(), expectedOperation.getParameters(), httpMethod,
-                    path);
+                validateParameters(actualOperation.getParameters(), expectedOperation.getParameters(), httpMethod, path);
                 //Validate responses
                 validateResponses(actualOperation.getResponses(), expectedOperation.getResponses(), httpMethod, path);
             }
@@ -285,17 +262,13 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         }
     }
 
-    private void validateParameters(List<Parameter> actualOperationParameters,
-        List<Parameter> expectedOperationParameters, String httpMethod, String path) {
+    private void validateParameters(List<Parameter> actualOperationParameters,  List<Parameter> expectedOperationParameters, String httpMethod, String path) {
         String message = String.format("Checking parameters of '%s' operation of path '%s'", httpMethod, path);
         if (CollectionUtils.isNotEmpty(expectedOperationParameters)) {
             softAssertions.assertThat(actualOperationParameters).as(message).isNotEmpty();
             if (CollectionUtils.isNotEmpty(actualOperationParameters)) {
-                softAssertions.assertThat(actualOperationParameters).as(message)
-                    .hasSameSizeAs(expectedOperationParameters);
-                softAssertions.assertThat(actualOperationParameters).as(message)
-                    .usingElementComparatorOnFields("in", "name", "required")
-                    .hasSameElementsAs(expectedOperationParameters);
+                softAssertions.assertThat(actualOperationParameters).as(message).hasSameSizeAs(expectedOperationParameters);
+                softAssertions.assertThat(actualOperationParameters).as(message).usingElementComparatorOnFields("in", "name", "required").hasSameElementsAs(expectedOperationParameters);
                 Map<String, Parameter> expectedParametersAsMap = new HashMap<>();
                 for (Parameter expectedParameter : expectedOperationParameters) {
                     expectedParametersAsMap.put(expectedParameter.getName(), expectedParameter);
@@ -311,89 +284,73 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         }
     }
 
-    private void validateParameter(Parameter actualParameter, Parameter expectedParameter, String parameterName,
-        String httpMethod, String path) {
+    private void validateParameter(Parameter actualParameter, Parameter expectedParameter, String parameterName, String httpMethod, String path) {
         if (expectedParameter != null) {
-            String message = String
-                .format("Checking parameter '%s' of '%s' operation of path '%s'", parameterName, httpMethod, path);
+            String message = String.format("Checking parameter '%s' of '%s' operation of path '%s'", parameterName, httpMethod, path);
             softAssertions.assertThat(actualParameter).as(message).isExactlyInstanceOf(expectedParameter.getClass());
             if (expectedParameter instanceof BodyParameter && actualParameter instanceof BodyParameter) {
                 BodyParameter actualBodyParameter = (BodyParameter) expectedParameter;
                 BodyParameter expectedBodyParameter = (BodyParameter) expectedParameter;
-                validateModel(actualBodyParameter.getSchema(), expectedBodyParameter.getSchema(), String
-                    .format("Checking model of parameter '%s' of '%s' operation of path '%s'", parameterName,
-                        httpMethod, path));
+                validateModel(actualBodyParameter.getSchema(), expectedBodyParameter.getSchema(), String.format("Checking model of parameter '%s' of '%s' operation of path '%s'", parameterName, httpMethod, path));
             } else if (expectedParameter instanceof PathParameter && actualParameter instanceof PathParameter) {
                 PathParameter actualPathParameter = (PathParameter) actualParameter;
                 PathParameter expectedPathParameter = (PathParameter) expectedParameter;
-                softAssertions.assertThat(actualPathParameter.getType()).as(message)
-                    .isEqualTo(expectedPathParameter.getType());
+                softAssertions.assertThat(actualPathParameter.getType()).as(message).isEqualTo(expectedPathParameter.getType());
                 List<String> expectedEnums = expectedPathParameter.getEnum();
                 if (CollectionUtils.isNotEmpty(expectedEnums)) {
-                    softAssertions.assertThat(actualPathParameter.getEnum()).as(message)
-                        .hasSameElementsAs(expectedEnums);
+                    softAssertions.assertThat(actualPathParameter.getEnum()).as(message).hasSameElementsAs(expectedEnums);
                 } else {
                     softAssertions.assertThat(actualPathParameter.getEnum()).as(message).isNullOrEmpty();
                 }
             } else if (expectedParameter instanceof QueryParameter && actualParameter instanceof QueryParameter) {
                 QueryParameter actualQueryParameter = (QueryParameter) actualParameter;
                 QueryParameter expectedQueryParameter = (QueryParameter) expectedParameter;
-                softAssertions.assertThat(actualQueryParameter.getType()).as(message)
-                    .isEqualTo(expectedQueryParameter.getType());
+                softAssertions.assertThat(actualQueryParameter.getType()).as(message).isEqualTo(expectedQueryParameter.getType());
                 List<String> expectedEnums = expectedQueryParameter.getEnum();
                 if (CollectionUtils.isNotEmpty(expectedEnums)) {
-                    softAssertions.assertThat(actualQueryParameter.getEnum()).as(message)
-                        .hasSameElementsAs(expectedEnums);
+                    softAssertions.assertThat(actualQueryParameter.getEnum()).as(message).hasSameElementsAs(expectedEnums);
                 } else {
                     softAssertions.assertThat(actualQueryParameter.getEnum()).as(message).isNullOrEmpty();
                 }
             } else if (expectedParameter instanceof HeaderParameter && actualParameter instanceof HeaderParameter) {
                 HeaderParameter actualHeaderParameter = (HeaderParameter) actualParameter;
                 HeaderParameter expectedHeaderParameter = (HeaderParameter) expectedParameter;
-                softAssertions.assertThat(actualHeaderParameter.getType()).as(message)
-                    .isEqualTo(expectedHeaderParameter.getType());
+                softAssertions.assertThat(actualHeaderParameter.getType()).as(message).isEqualTo(expectedHeaderParameter.getType());
                 List<String> expectedEnums = expectedHeaderParameter.getEnum();
                 if (CollectionUtils.isNotEmpty(expectedEnums)) {
-                    softAssertions.assertThat(actualHeaderParameter.getEnum()).as(message)
-                        .hasSameElementsAs(expectedEnums);
+                    softAssertions.assertThat(actualHeaderParameter.getEnum()).as(message).hasSameElementsAs(expectedEnums);
                 } else {
                     softAssertions.assertThat(actualHeaderParameter.getEnum()).as(message).isNullOrEmpty();
                 }
             } else if (expectedParameter instanceof FormParameter && actualParameter instanceof FormParameter) {
                 FormParameter actualFormParameter = (FormParameter) actualParameter;
                 FormParameter expectedFormParameter = (FormParameter) expectedParameter;
-                softAssertions.assertThat(actualFormParameter.getType()).as(message)
-                    .isEqualTo(expectedFormParameter.getType());
+                softAssertions.assertThat(actualFormParameter.getType()).as(message).isEqualTo(expectedFormParameter.getType());
                 List<String> expectedEnums = expectedFormParameter.getEnum();
                 if (CollectionUtils.isNotEmpty(expectedEnums)) {
-                    softAssertions.assertThat(actualFormParameter.getEnum()).as(message)
-                        .hasSameElementsAs(expectedEnums);
+                    softAssertions.assertThat(actualFormParameter.getEnum()).as(message).hasSameElementsAs(expectedEnums);
                 } else {
                     softAssertions.assertThat(actualFormParameter.getEnum()).as(message).isNullOrEmpty();
                 }
             } else if (expectedParameter instanceof CookieParameter && actualParameter instanceof CookieParameter) {
                 CookieParameter actualCookieParameter = (CookieParameter) actualParameter;
                 CookieParameter expectedCookieParameter = (CookieParameter) expectedParameter;
-                softAssertions.assertThat(actualCookieParameter.getType()).as(message)
-                    .isEqualTo(expectedCookieParameter.getType());
+                softAssertions.assertThat(actualCookieParameter.getType()).as(message).isEqualTo(expectedCookieParameter.getType());
                 List<String> expectedEnums = expectedCookieParameter.getEnum();
                 if (CollectionUtils.isNotEmpty(expectedEnums)) {
-                    softAssertions.assertThat(actualCookieParameter.getEnum()).as(message)
-                        .hasSameElementsAs(expectedEnums);
+                    softAssertions.assertThat(actualCookieParameter.getEnum()).as(message).hasSameElementsAs(expectedEnums);
                 } else {
                     softAssertions.assertThat(actualCookieParameter.getEnum()).as(message).isNullOrEmpty();
                 }
             } else if (expectedParameter instanceof RefParameter && actualParameter instanceof RefParameter) {
                 RefParameter expectedRefParameter = (RefParameter) expectedParameter;
                 RefParameter actualRefParameter = (RefParameter) actualParameter;
-                softAssertions.assertThat(actualRefParameter.getSimpleRef()).as(message)
-                    .isEqualTo(expectedRefParameter.getSimpleRef());
+                softAssertions.assertThat(actualRefParameter.getSimpleRef()).as(message).isEqualTo(expectedRefParameter.getSimpleRef());
             }
         }
     }
 
-    private void validateResponses(Map<String, Response> actualOperationResponses,
-        Map<String, Response> expectedOperationResponses, String httpMethod, String path) {
+    private void validateResponses(Map<String, Response> actualOperationResponses, Map<String, Response> expectedOperationResponses, String httpMethod, String path) {
         String message = String.format("Checking responses of '%s' operation of path '%s'", httpMethod, path);
         if (MapUtils.isNotEmpty(expectedOperationResponses)) {
             softAssertions.assertThat(actualOperationResponses).as(message).isNotEmpty();
@@ -411,45 +368,32 @@ class DocumentationDrivenValidator extends AbstractContractValidator {
         }
     }
 
-    private void validateResponseByConfig(Map<String, Response> actualOperationResponses,
-        Map<String, Response> expectedOperationResponses, String message) {
-        if (isAssertionEnabled(SwaggerAssertionType.STRICT_VALIDATION_ON_PATH)) {
-            softAssertions.assertThat(actualOperationResponses.keySet()).as(message)
-                .hasSameElementsAs(expectedOperationResponses.keySet());
+    private void validateResponseByConfig(Map<String, Response> actualOperationResponses, Map<String, Response> expectedOperationResponses, String message) {
+        if(isAssertionEnabled(SwaggerAssertionType.STRICT_VALIDATION_ON_PATH)) {
+            softAssertions.assertThat(actualOperationResponses.keySet()).as(message).hasSameElementsAs(expectedOperationResponses.keySet());
         } else {
-            softAssertions.assertThat(actualOperationResponses.keySet()).as(message)
-                .containsAll(expectedOperationResponses.keySet());
+            softAssertions.assertThat(actualOperationResponses.keySet()).as(message).containsAll(expectedOperationResponses.keySet());
         }
     }
 
-    private void validateResponse(Response actualResponse, Response expectedResponse, String responseName,
-        String httpMethod, String path) {
+    private void validateResponse(Response actualResponse, Response expectedResponse, String responseName, String httpMethod, String path) {
         if (expectedResponse != null) {
-            validateProperty(actualResponse.getSchema(), expectedResponse.getSchema(), String
-                .format("Checking response schema of response '%s' of '%s' operation of path '%s'", responseName,
-                    httpMethod, path));
-            validateResponseHeaders(actualResponse.getHeaders(), expectedResponse.getHeaders(), responseName,
-                httpMethod, path);
+            validateProperty(actualResponse.getSchema(), expectedResponse.getSchema(), String.format("Checking response schema of response '%s' of '%s' operation of path '%s'", responseName, httpMethod, path));
+            validateResponseHeaders(actualResponse.getHeaders(), expectedResponse.getHeaders(), responseName, httpMethod, path);
         }
     }
 
-    private void validateResponseHeaders(Map<String, Property> actualResponseHeaders,
-        Map<String, Property> expectedResponseHeaders, String responseName, String httpMethod, String path) {
-        String message = String
-            .format("Checking response headers of response '%s' of '%s' operation of path '%s'", responseName,
-                httpMethod, path);
+    private void validateResponseHeaders(Map<String, Property> actualResponseHeaders, Map<String, Property> expectedResponseHeaders, String responseName, String httpMethod, String path) {
+        String message = String.format("Checking response headers of response '%s' of '%s' operation of path '%s'", responseName, httpMethod, path);
         if (MapUtils.isNotEmpty(expectedResponseHeaders)) {
             softAssertions.assertThat(actualResponseHeaders).as(message).isNotEmpty();
             if (MapUtils.isNotEmpty(actualResponseHeaders)) {
-                softAssertions.assertThat(actualResponseHeaders.keySet()).as(message)
-                    .hasSameElementsAs(expectedResponseHeaders.keySet());
+                softAssertions.assertThat(actualResponseHeaders.keySet()).as(message).hasSameElementsAs(expectedResponseHeaders.keySet());
                 for (Map.Entry<String, Property> actualResponseHeaderEntry : actualResponseHeaders.entrySet()) {
                     Property expectedResponseHeader = expectedResponseHeaders.get(actualResponseHeaderEntry.getKey());
                     Property actualResponseHeader = actualResponseHeaderEntry.getValue();
                     String responseHeaderName = actualResponseHeaderEntry.getKey();
-                    validateProperty(actualResponseHeader, expectedResponseHeader, String
-                        .format("Checking response header '%s' of response '%s' of '%s' operation of path '%s'",
-                            responseHeaderName, responseName, httpMethod, path));
+                    validateProperty(actualResponseHeader, expectedResponseHeader, String.format("Checking response header '%s' of response '%s' of '%s' operation of path '%s'", responseHeaderName, responseName, httpMethod, path));
                 }
             }
         } else {

--- a/src/main/java/io/github/robwin/swagger/test/PropertyValidator.java
+++ b/src/main/java/io/github/robwin/swagger/test/PropertyValidator.java
@@ -1,0 +1,100 @@
+package io.github.robwin.swagger.test;
+
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.ByteArrayProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
+import java.util.List;
+import org.apache.commons.collections.CollectionUtils;
+import org.assertj.core.api.SoftAssertions;
+
+public class PropertyValidator {
+
+    /**
+     * Basic properties that impacts swagger contract.
+     */
+    private static final String[] BASIC_PROPERTIES = {"type", "format", "allowEmptyValue", "name", "required",
+        "readOnly", "access", "vendorExtensions"};
+
+    private SwaggerAssertionConfig assertionConfig;
+    private SoftAssertions softAssertions;
+
+    public PropertyValidator(SwaggerAssertionConfig assertionConfig, SoftAssertions softAssertions) {
+        this.assertionConfig = assertionConfig;
+        this.softAssertions = softAssertions;
+    }
+
+    void validateProperty(Property actualProperty, Property expectedProperty, String message) {
+        if (expectedProperty == null || !isAssertionEnabled(SwaggerAssertionType.PROPERTIES)) {
+            return;
+        }
+
+        // TODO Validate Property schema
+        if (shouldValidateRefProperty(expectedProperty)) {
+            validateBasicPropertyFeatures(actualProperty, expectedProperty, message);
+            // TODO improve validation by verifying property based on RefProperty type
+        } else if (shouldValidateArrayProperty(expectedProperty)) {
+            validateBasicPropertyFeatures(actualProperty, expectedProperty, message);
+            // TODO improve validation by verifying property based on ArrayProperty type
+        } else if (shouldValidateByteArrayProperty(expectedProperty)) {
+            validateBasicPropertyFeatures(actualProperty, expectedProperty, message);
+            // TODO improve validation by verifying property based on ByteArrayProperty type
+        } else if (shouldValidateStringProperty(expectedProperty)) {
+            StringProperty expectedStringProperty = (StringProperty) expectedProperty;
+            validateBasicPropertyFeatures(actualProperty, expectedProperty, message);
+            if (isPropertyOfEnumType(actualProperty)) {
+                StringProperty actualStringProperty = (StringProperty) actualProperty;
+                validateEnumPropertyFeatures(actualStringProperty, expectedStringProperty);
+            }
+        } else {
+            validateBasicPropertyFeatures(actualProperty, expectedProperty, message);
+        }
+    }
+
+    private boolean shouldValidateRefProperty(Property expectedProperty) {
+        return RefProperty.class.isAssignableFrom(expectedProperty.getClass()) && isAssertionEnabled(
+            SwaggerAssertionType.REF_PROPERTIES);
+    }
+
+    private boolean shouldValidateArrayProperty(Property expectedProperty) {
+        return ArrayProperty.class.isAssignableFrom(expectedProperty.getClass()) && isAssertionEnabled(
+            SwaggerAssertionType.ARRAY_PROPERTIES);
+    }
+
+    private boolean shouldValidateByteArrayProperty(Property expectedProperty) {
+        return ByteArrayProperty.class.isAssignableFrom(expectedProperty.getClass()) && isAssertionEnabled(
+            SwaggerAssertionType.BYTE_ARRAY_PROPERTIES);
+    }
+
+    private boolean shouldValidateStringProperty(Property expectedProperty) {
+        return StringProperty.class.isAssignableFrom(expectedProperty.getClass()) && isAssertionEnabled(
+            SwaggerAssertionType.STRING_PROPERTIES);
+    }
+
+    private boolean isAssertionEnabled(final SwaggerAssertionType assertionType) {
+        return assertionConfig.swaggerAssertionEnabled(assertionType);
+    }
+
+    private void validateBasicPropertyFeatures(Property actualProperty, Property expectedProperty, String message) {
+        softAssertions.assertThat(actualProperty).as(message).isExactlyInstanceOf(expectedProperty.getClass());
+        softAssertions.assertThat(actualProperty).as(message)
+            .isEqualToComparingOnlyGivenFields(expectedProperty, BASIC_PROPERTIES);
+    }
+
+    private boolean isPropertyOfEnumType(Property property) {
+        return property != null && StringProperty.class.isAssignableFrom(property.getClass())
+            && CollectionUtils.isNotEmpty(((StringProperty) property).getEnum());
+    }
+
+    private void validateEnumPropertyFeatures(StringProperty actualStringProperty,
+        StringProperty expectedStringProperty) {
+        List<String> expectedEnums = expectedStringProperty.getEnum();
+        if (CollectionUtils.isNotEmpty(expectedEnums)) {
+            softAssertions.assertThat(actualStringProperty.getEnum()).hasSameElementsAs(expectedEnums);
+        } else {
+            softAssertions.assertThat(actualStringProperty.getEnum()).isNullOrEmpty();
+        }
+    }
+
+}

--- a/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionType.java
+++ b/src/main/java/io/github/robwin/swagger/test/SwaggerAssertionType.java
@@ -30,6 +30,7 @@ public enum SwaggerAssertionType {
         PROPERTIES("validateProperties", true),
             REF_PROPERTIES("validateRefProperties", true),
             ARRAY_PROPERTIES("validateArrayProperties", true),
+            BYTE_ARRAY_PROPERTIES("validateByteArrayProperties", true),
             STRING_PROPERTIES("validateStringProperties", true),
         MODELS("validateModels", true),
     PATHS("validatePaths", true),

--- a/src/test/java/io/github/robwin/swagger/SwaggerDocumentationDrivenAssertTest.java
+++ b/src/test/java/io/github/robwin/swagger/SwaggerDocumentationDrivenAssertTest.java
@@ -34,6 +34,7 @@ import org.junit.After;
 import org.junit.Test;
 
 public class SwaggerDocumentationDrivenAssertTest {
+
     private static final String SWAGGER_CONFIG_LOCATION = "assertj-swagger.properties";
     private static final File SWAGGER_CONFIG = new File(SWAGGER_CONFIG_LOCATION);
 
@@ -44,130 +45,217 @@ public class SwaggerDocumentationDrivenAssertTest {
 
     @Test
     public void shouldFindNoDifferences() {
-        File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.json").getFile());
-        File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getFile());
-        SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.json").getFile());
+        File designFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getFile());
+        SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath())
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
     public void shouldFindDifferencesInImplementation() {
-        File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/wrong_swagger.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
-        SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/wrong_swagger.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
+        SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath())
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
     public void shouldFindDifferencesInParameterNaming() {
-        File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger-name-changes.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
-        SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger-name-changes.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
+        SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath())
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
     public void shouldFindDifferencesInRequiredness() {
-        File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger-requiredness-changes.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
-        SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath()).isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger-requiredness-changes.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
+        SwaggerAssertions.assertThat(implFirstSwaggerLocation.getAbsolutePath())
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
     public void shouldFindDifferencesInInfo() {
         // Otherwise-good comparison will fail here, because 'info.title' is different
-        File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
-        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-info.properties")
-                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()),
+            "/assertj-swagger-info.properties")
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test
     public void shouldHandlePartiallyImplementedApi() {
-        File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/partial_impl_swagger.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/partial_impl_swagger.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
 
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
-        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-partial-impl.properties")
-                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()),
+            "/assertj-swagger-partial-impl.properties")
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test
     public void shouldHandleExpectedPathsWithPrefix() {
-        File implFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger_with_path_prefixes.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger_with_path_prefixes.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerDocumentationDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
 
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
-        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-path-prefix.properties")
-                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()),
+            "/assertj-swagger-path-prefix.properties")
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test
     public void shouldHandleDefinitionsUsingAllOf() {
-        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-flat.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-inheritance.json").getPath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-flat.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-inheritance.json").getPath());
 
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
-        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-allOf.properties")
-                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()),
+            "/assertj-swagger-allOf.properties")
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test
     public void shouldHandleDefinitionsUsingAllOfIncludingCycles() {
-        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-flat.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-inheritance-cycles.json").getPath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-flat.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-test-inheritance-cycles.json").getPath());
 
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
-        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), "/assertj-swagger-allOf.properties")
-                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()),
+            "/assertj-swagger-allOf.properties")
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test
     public void shouldHandleDefinitionsUsingAllOfForComposition() {
-        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-composition-flat.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-composition.json").getPath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-composition-flat.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-allOf-composition.json").getPath());
 
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
-                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
     public void shouldFindDifferentRequiredFieldsForObjectDefinition() {
-        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-missing-required-field-object.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-missing-required-field-object.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.yaml").getPath());
 
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
-                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
+    @Test
+    public void shouldHandleByteArrayValues() {
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-bytearray.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-bytearray.yaml").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void shouldFindDifferentByteArrayValues() {
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-bytearray-wrong.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-bytearray.yaml").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
+    @Test
+    public void shouldRefHandleByteArrayValues() {
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-bytearray-ref.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-bytearray-ref.yaml").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void shouldFindDifferentRefByteArrayValues() {
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-bytearray-ref-wrong.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-bytearray-ref.yaml").getPath());
+
+        Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
+        new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test
     public void shouldHandleEnumValues() {
-        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum.yaml").getPath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum.yaml").getPath());
 
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
-                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
     public void shouldFindDifferentEnumValues() {
-        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-wrong.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum.yaml").getPath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-wrong.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum.yaml").getPath());
 
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
-                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test
     public void shouldAllowConfigurationToLooselyMatchResponse() throws IOException {
-        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/designed-swagger-with-less-response-defined.yaml").getPath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/designed-swagger-with-less-response-defined.yaml")
+                .getPath());
         configureSwaggerAssertion();
 
         SwaggerAssertionConfig config = getConfig();
 
-        SwaggerAssert swaggerAssert = new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), config);
+        SwaggerAssert swaggerAssert = new SwaggerAssert(
+            new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()), config);
         swaggerAssert.isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
@@ -184,24 +272,28 @@ public class SwaggerDocumentationDrivenAssertTest {
     private String toConfiguration() {
         return "assertj.swagger.validateResponseWithStrictlyMatch=false";
     }
-        
+
     @Test
     public void shouldHandleRefEnumValues() {
-        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref.yaml").getPath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref.yaml").getPath());
 
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
-                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 
     @Test(expected = AssertionError.class)
     public void shouldFindDifferentRefEnumValues() {
-        File implFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref-wrong.json").getPath());
-        File designFirstSwaggerLocation = new File(SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref.yaml").getPath());
+        File implFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref-wrong.json").getPath());
+        File designFirstSwaggerLocation = new File(
+            SwaggerConsumerDrivenAssertTest.class.getResource("/swagger-enum-ref.yaml").getPath());
 
         Validate.notNull(implFirstSwaggerLocation.getAbsolutePath(), "actualLocation must not be null!");
         new SwaggerAssert(new SwaggerParser().read(implFirstSwaggerLocation.getAbsolutePath()))
-                .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
+            .isEqualTo(designFirstSwaggerLocation.getAbsolutePath());
     }
 }

--- a/src/test/resources/swagger-bytearray-ref-wrong.json
+++ b/src/test/resources/swagger-bytearray-ref-wrong.json
@@ -1,0 +1,80 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "This is a sample server Petstore server.\n\n[Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.\n\nFor this sample, you can use the api key `special-key` to test the authorization filters\n",
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "termsOfService": "http://helloreverb.com/terms/",
+        "contact": {
+            "name": "apiteam@wordnik.com"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        }
+    },
+    "host": "petstore.swagger.wordnik.com",
+    "basePath": "/v2",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/documents/{id}": {
+            "get": {
+                "tags": [
+                    "Documents"
+                ],
+                "summary": "Get document by id",
+                "description": "",
+                "operationId": "getDocumentById",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "description": "The document that needs to be fetched.",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Document"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request"
+                    },
+                    "404": {
+                        "description": "Document not found"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Document": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "content": {
+                    "$ref": "#/definitions/DocumentContent"
+                }
+            }
+        },
+        "DocumentContent": {
+            "description": "Document content",
+            "type": "string"
+        }
+    }
+}

--- a/src/test/resources/swagger-bytearray-ref.json
+++ b/src/test/resources/swagger-bytearray-ref.json
@@ -1,0 +1,81 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "This is a sample server Petstore server.\n\n[Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.\n\nFor this sample, you can use the api key `special-key` to test the authorization filters\n",
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "termsOfService": "http://helloreverb.com/terms/",
+        "contact": {
+            "name": "apiteam@wordnik.com"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        }
+    },
+    "host": "petstore.swagger.wordnik.com",
+    "basePath": "/v2",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/documents/{id}": {
+            "get": {
+                "tags": [
+                    "Documents"
+                ],
+                "summary": "Get document by id",
+                "description": "",
+                "operationId": "getDocumentById",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "description": "The document that needs to be fetched.",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Document"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request"
+                    },
+                    "404": {
+                        "description": "Document not found"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Document": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "content": {
+                    "$ref": "#/definitions/DocumentContent"
+                }
+            }
+        },
+        "DocumentContent": {
+            "description": "Document content",
+            "type": "string",
+            "format": "byte"
+        }
+    }
+}

--- a/src/test/resources/swagger-bytearray-ref.yaml
+++ b/src/test/resources/swagger-bytearray-ref.yaml
@@ -1,0 +1,81 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is a sample server Petstore server.\n\n[Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.\n\nFor this sample, you can use the api key `special-key` to test the authorization filters\n",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://helloreverb.com/terms/",
+    "contact": {
+      "name": "apiteam@wordnik.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "host": "petstore.swagger.wordnik.com",
+  "basePath": "/v2",
+  "schemes": [
+    "http"
+  ],
+  "paths": {
+    "/documents/{id}": {
+      "get": {
+        "tags": [
+          "Documents"
+        ],
+        "summary": "Get document by id",
+        "description": "",
+        "operationId": "getDocumentById",
+        "produces": [
+          "application/json",
+          "application/xml"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "description": "The document that needs to be fetched.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "$ref": "#/definitions/Document"
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "404": {
+            "description": "Document not found"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Document": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "name": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/definitions/DocumentContent"
+        }
+      }
+    },
+    "DocumentContent": {
+      "description": "Document content",
+      "type": "string",
+      "format": "byte"
+    }
+  }
+}

--- a/src/test/resources/swagger-bytearray-wrong.json
+++ b/src/test/resources/swagger-bytearray-wrong.json
@@ -1,0 +1,77 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "This is a sample server Petstore server.\n\n[Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.\n\nFor this sample, you can use the api key `special-key` to test the authorization filters\n",
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "termsOfService": "http://helloreverb.com/terms/",
+        "contact": {
+            "name": "apiteam@wordnik.com"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        }
+    },
+    "host": "petstore.swagger.wordnik.com",
+    "basePath": "/v2",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/documents/{id}": {
+            "get": {
+                "tags": [
+                    "Documents"
+                ],
+                "summary": "Get document by id",
+                "description": "",
+                "operationId": "getDocumentById",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "description": "The document that needs to be fetched.",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Document"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request"
+                    },
+                    "404": {
+                        "description": "Document not found"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Document": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "content": {
+                    "description": "Document content",
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/swagger-bytearray.json
+++ b/src/test/resources/swagger-bytearray.json
@@ -1,0 +1,78 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "This is a sample server Petstore server.\n\n[Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.\n\nFor this sample, you can use the api key `special-key` to test the authorization filters\n",
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "termsOfService": "http://helloreverb.com/terms/",
+        "contact": {
+            "name": "apiteam@wordnik.com"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+        }
+    },
+    "host": "petstore.swagger.wordnik.com",
+    "basePath": "/v2",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/documents/{id}": {
+            "get": {
+                "tags": [
+                    "Documents"
+                ],
+                "summary": "Get document by id",
+                "description": "",
+                "operationId": "getDocumentById",
+                "produces": [
+                    "application/json",
+                    "application/xml"
+                ],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "description": "The document that needs to be fetched.",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/Document"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request"
+                    },
+                    "404": {
+                        "description": "Document not found"
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Document": {
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "content": {
+                    "description": "Document content",
+                    "type": "string",
+                    "format": "byte"
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/swagger-bytearray.yaml
+++ b/src/test/resources/swagger-bytearray.yaml
@@ -1,0 +1,58 @@
+swagger: "2.0"
+info:
+  description: |
+    This is a sample server Petstore server.
+
+    [Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.
+
+    For this sample, you can use the api key `special-key` to test the authorization filters
+  version: "1.0.0"
+  title: Swagger Petstore
+  termsOfService: http://helloreverb.com/terms/
+  contact:
+    name: apiteam@wordnik.com
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+host: petstore.swagger.wordnik.com
+basePath: /v2
+schemes:
+  - http
+paths:
+  /documents/{id}:
+    get:
+      tags:
+        - Documents
+      summary: Get document by id
+      description: ""
+      operationId: getDocumentById
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: path
+          name: id
+          description: The document that needs to be fetched.
+          required: true
+          type: string
+      responses:
+        "404":
+          description: Document not found
+        "200":
+          description: successful operation
+          schema:
+            $ref: "#/definitions/Document"
+        "400":
+          description: Invalid request
+definitions:
+  Document:
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      content:
+        description: 'Document content'
+        type: string
+        format: byte


### PR DESCRIPTION
* Added ByteArrayProperty validation.
* Added 'validateByteArrayProperties' property to enable/disable validation.
* Removed 'properties validation' duplicated code from DocumentationDrivenValidator and ConsumerDriverValidator. Code moved to PropertyValidator class.
* PropertyValidator : Refactored code. Changed 'instanceOf' operator to Type.class.isAssignableFrom(...). It provides more strict and faster type check operation.
* Introduced swagger model type and format definitions validation in DocumentationDrivenValidator.
* Added tests which cover  swagger simple definitions and REF defintions.
* Documentation update.