### PR TITLE
[Rajeswari|Nandha] Add OWASP dependency check and fix the vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.18"
+        classpath 'org.owasp:dependency-check-gradle:3.3.2'
     }
 }
 description = 'A Swagger assertion library'
@@ -20,6 +21,7 @@ apply plugin: 'com.github.kt3k.coveralls'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: "com.jfrog.artifactory"
 apply from: 'gradle/publishing.gradle'
+apply from: 'gradle/security.gradle'
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = "1.8"
@@ -36,8 +38,8 @@ repositories {
 }
 
 dependencies {
-    compile "io.swagger:swagger-compat-spec-parser:1.0.34"
-    compile "commons-collections:commons-collections:3.2.1"
+    compile "io.swagger:swagger-compat-spec-parser:1.0.35"
+    compile "commons-collections:commons-collections:3.2.2"
     compile "org.slf4j:slf4j-api:1.7.12"
     compile "org.assertj:assertj-core:3.9.1"
     testCompile "junit:junit:4.11"

--- a/gradle/security.gradle
+++ b/gradle/security.gradle
@@ -1,0 +1,20 @@
+apply plugin: 'org.owasp.dependencycheck'
+
+check.dependsOn dependencyCheckAnalyze
+
+dependencyCheck {
+    cveValidForHours = 8
+    failBuildOnCVSS = 5
+    analyzers {
+        nexusEnabled = false
+        pyDistributionEnabled = false
+        pyPackageEnabled = false
+        rubygemsEnabled = false
+        cmakeEnabled = false
+        autoconfEnabled = false
+        composerEnabled = false
+        nodeEnabled = false
+        nuspecEnabled = false
+        assemblyEnabled = false
+    }
+}


### PR DESCRIPTION
We have used assertj-swagger in our project and we also have OWASP dependency checker for analysing vulnerabilities. The dependency checker complained about 2 dependencies of assertj-swagger -> commons-collections and jackson-databind (a dependency of swagger-compat-spec-parser).

This PR adds dependency check analyser to the build and also fixes the existing vulnerabilities by upgrading them to the closest version that has the fix.